### PR TITLE
Verbose function names

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -8,10 +8,10 @@ describe("Selection Class", function() {
     expect( Selection.prototype.hasOwnProperty("isAllSelected") ).toEqual(true);
   });
 
-  it("should have isAtTheEnd() method from Cursor in its protoype chain", function() {
-    expect( Selection.prototype.hasOwnProperty("isAtTheEnd") ).toEqual(false);
-    expect( Cursor.prototype.hasOwnProperty("isAtTheEnd") ).toEqual(true);
-    expect( "isAtTheEnd" in Selection.prototype ).toEqual(true);
+  it("should have isAtEnd() method from Cursor in its protoype chain", function() {
+    expect( Selection.prototype.hasOwnProperty("isAtEnd") ).toEqual(false);
+    expect( Cursor.prototype.hasOwnProperty("isAtEnd") ).toEqual(true);
+    expect( "isAtEnd" in Selection.prototype ).toEqual(true);
   });
 
 });

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -54,11 +54,11 @@ var behavior = (function() {
       log(cursor);
       log('Default newline behavior');
 
-      var atTheEnd = cursor.isAtTheEnd();
+      var atEnd = cursor.isAtEnd();
       var br = document.createElement('br');
       cursor.insertBefore(br);
 
-      if(atTheEnd) {
+      if(atEnd) {
         log('at the end');
 
         var noWidthSpace = document.createTextNode('\u200B');

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -20,14 +20,14 @@ var Cursor = (function() {
 
   Cursor.prototype = (function() {
     return {
-      isAtTheEnd: function() {
+      isAtEnd: function() {
         return parser.isEndOfHost(
           this.host,
           this.range.endContainer,
           this.range.endOffset);
       },
 
-      isAtTheBeginning: function() {
+      isAtBeginning: function() {
         return parser.isBeginningOfHost(
           this.host,
           this.range.startContainer,

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -66,7 +66,7 @@ var dispatcher = (function() {
       log('Backspace key pressed');
 
       var cursor = selectionWatcher.getCursor();
-      if(cursor.isAtTheBeginning()) {
+      if(cursor.isAtBeginning()) {
         event.preventDefault();
         event.stopPropagation();
         notifier('merge', this, 'before', cursor);
@@ -75,7 +75,7 @@ var dispatcher = (function() {
       log('Delete key pressed');
 
       var cursor = selectionWatcher.getCursor();
-      if(cursor.isAtTheEnd()) {
+      if(cursor.isAtEnd()) {
         event.preventDefault();
         event.stopPropagation();
         notifier('merge', this, 'after', cursor);
@@ -87,9 +87,9 @@ var dispatcher = (function() {
       event.stopPropagation();
       var cursor = selectionWatcher.getCursor();
 
-      if (cursor.isAtTheBeginning()) {
+      if (cursor.isAtBeginning()) {
         notifier('insert', this, 'before', cursor);
-      } else if(cursor.isAtTheEnd()) {
+      } else if(cursor.isAtEnd()) {
         notifier('insert', this, 'after', cursor);
       } else {
         notifier('split', this, cursor.before(), cursor.after(), cursor);


### PR DESCRIPTION
I've been glancing over the codebase and there's one thing that I found to be a bit too verbose. In `src/cursor.js` there are several methods that have `the` in their names.
- `isAtTheEnd`
- `isAtTheBeginning`
- `moveAtTheEnd`
- `moveAtTheBeginning`

In my opinion, these would read nicer without `the`. Also, if I understood the `move` methods correctly, they move the cursor before or after an element. Wouldn't it make more sense to name them `moveTo{End,Beginning}` or maybe even `move{Before,After}Element`?
