### PR TITLE
Bug: ranges are reset for old events

### DIFF
--- a/src/selection-watcher.js
+++ b/src/selection-watcher.js
@@ -20,7 +20,7 @@ var selectionWatcher = (function() {
 
     // rangeCount is 0 or 1 in all browsers except firefox
     // firefox can work with multiple ranges
-    // (I don't know if this occurs from normal use though)
+    // (on a mac hold down the command key to select multiple ranges)
     if (rangySelection.rangeCount) {
       var range = rangySelection.getRangeAt(0);
       var editableSelector = '.' + config.editableClass;


### PR DESCRIPTION
Problem: When writing a link in a text input field in order to set the link on a selection. One needs to set the focus on the text field. At that moment the selection gets reset. With the current implementation in `selectionWatcher#getRangeContainer()` the range of old events gets refreshed as well. Making it impossible in the above scenario to apply the link to the old selection.

Most likely it wasn't a smart move in the beginning to share the ranges between multiple cursors and selections
