### PR TITLE
Bug: Cursor#insertAfter and #insertBefore throw errors for empty documentFragments

### DIFF
--- a/spec/cursor.spec.js
+++ b/spec/cursor.spec.js
@@ -27,12 +27,14 @@ describe('Cursor', function() {
     });
 
     describe('isAtEnd()', function() {
+
       it('is true', function() {
         expect(this.cursor.isAtEnd()).toBe(true);
       });
     });
 
     describe('isAtBeginning()', function() {
+
       it('is false', function() {
         expect(this.cursor.isAtBeginning()).toBe(false);
       });
@@ -51,6 +53,28 @@ describe('Cursor', function() {
         expect(this.cursor.isAtEnd()).toBe(true);
       });
     });
-  });
 
+    describe('insertAfter()', function() {
+
+      it('can deal with an empty documentFragment', function() {
+        var test = function() {
+          var frag = window.document.createDocumentFragment();
+          this.cursor.insertAfter(frag);
+        }
+        expect($.proxy(test, this)).not.toThrow();
+      });
+    });
+
+    describe('insertBefore()', function() {
+
+      it('can deal with an empty documentFragment', function() {
+        var test = function() {
+          var frag = window.document.createDocumentFragment();
+          this.cursor.insertBefore(frag);
+        }
+        expect($.proxy(test, this)).not.toThrow();
+      });
+    });
+
+  });
 });

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -361,3 +361,29 @@ describe('Parser', function() {
   });
 
 });
+
+describe('isDocumentFragmentWithoutChildren()', function() {
+
+  beforeEach(function() {
+    this.frag = window.document.createDocumentFragment();
+  });
+
+  it('returns truthy for a fragment with no children', function() {
+    expect(parser.isDocumentFragmentWithoutChildren(this.frag)).toBeTruthy()
+  });
+
+  it('returns falsy for a documentFragment with an empty text node as child', function() {
+    this.frag.appendChild(window.document.createTextNode());
+    expect(parser.isDocumentFragmentWithoutChildren(this.frag)).toBeFalsy()
+  });
+
+  it('returns falsy for undefined', function() {
+    expect(parser.isDocumentFragmentWithoutChildren(undefined)).toBeFalsy()
+  });
+
+  it('returns falsy for an element node', function() {
+    var node = $('<div>')[0];
+    expect(parser.isDocumentFragmentWithoutChildren(node)).toBeFalsy()
+  });
+
+});

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -48,8 +48,9 @@ var Cursor = (function() {
        * @param DOM node or document fragment
        */
       insertBefore: function(element) {
-        var preceedingElement = element;
+        if (parser.isDocumentFragmentWithoutChildren(element)) return;
 
+        var preceedingElement = element;
         if (element.nodeType === 11) { // DOCUMENT_FRAGMENT_NODE
           var lastIndex = element.childNodes.length - 1;
           preceedingElement = element.childNodes[lastIndex];
@@ -66,6 +67,7 @@ var Cursor = (function() {
        * @param DOM node or document fragment
        */
       insertAfter: function(element) {
+        if (parser.isDocumentFragmentWithoutChildren(element)) return;
         this.range.insertNode(element);
       },
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -252,6 +252,23 @@ var parser = (function() {
         return this.latestChild(container.lastChild);
       else
         return container;
+    },
+
+    /**
+     * Checks if a documentFragment has no children.
+     * Fragments without children can cause errors if inserted into ranges.
+     *
+     * @method  isDocumentFragmentWithoutChildren
+     * @param  {HTMLElement} DOM node.
+     * @return {Boolean}
+     */
+    isDocumentFragmentWithoutChildren: function(fragment) {
+      if (fragment &&
+          fragment.nodeType === 11 &&
+          fragment.childNodes.length === 0) {
+        return true;
+      }
+      return false;
     }
   };
 })();


### PR DESCRIPTION
**Reproduce:**

This code throws an error:

``` javascript
var frag = window.document.createDocumentFragment();
cursor.insertBefore(frag);
```
