### PR TITLE
Fix suspend() and continue()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -160,6 +160,7 @@ const Editable = module.exports = class Editable {
     $elem = $elem || $('.' + config.editableClass, body)
 
     $elem.removeAttr('contenteditable')
+    this.dispatcher.suspend()
     return this
   }
 
@@ -174,6 +175,7 @@ const Editable = module.exports = class Editable {
     $elem = $elem || $('.' + config.editableClass, body)
 
     $elem.attr('contenteditable', true)
+    this.dispatcher.continue()
     return this
   }
   /**

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -39,21 +39,37 @@ export default class Dispatcher {
   * @method setup
   */
   setup () {
-    // setup all events notifications
-    this.setupElementListeners()
+    // setup all events listeners and keyboard handlers
     this.setupKeyboardEvents()
-    this.setupKeydownListener()
-
-    if (selectionchange) {
-      this.setupSelectionChangeListeners()
-    } else {
-      this.setupSelectionChangeFallback()
-    }
+    this.setupEventListeners()
   }
 
   unload () {
     this.off()
     this.$document.off('.editable')
+  }
+
+  suspend () {
+    if (this.suspended) return
+    this.suspended = true
+    this.$document.off('.editable')
+  }
+
+  continue () {
+    if (!this.suspended) return
+    this.suspended = false
+    this.setupEventListeners()
+  }
+
+  setupEventListeners () {
+    this.setupElementListeners()
+    this.setupKeydownListener()
+
+    if (selectionchange) {
+      this.setupSelectionChangeListeners()
+    } else {
+      this.setupSelectionChangeFallbackListeners()
+    }
   }
 
   /**
@@ -300,16 +316,14 @@ export default class Dispatcher {
   * Fallback solution to support selection change events on browsers that don't
   * support selectionChange.
   *
-  * @method setupSelectionChangeFallback
-  * @param {HTMLElement} $document: The document element.
-  * @param {Function} notifier: The callback to be triggered when the event is caught.
+  * @method setupSelectionChangeFallbackListeners
   */
-  setupSelectionChangeFallback () {
+  setupSelectionChangeFallbackListeners () {
     const $document = this.$document
     const selectionWatcher = this.selectionWatcher
 
     // listen for selection changes by mouse
-    $document.on('mouseup.editableSelection', (event) => {
+    $document.on('mouseup.editable', (event) => {
       // In Opera when clicking outside of a block
       // it does not update the selection as it should
       // without the timeout

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -19,6 +19,7 @@ var isInputEventSupported = false
  * @submodule dispatcher
  */
 export default class Dispatcher {
+
   constructor (editable) {
     const win = editable.win
     eventable(this, editable)
@@ -39,11 +40,12 @@ export default class Dispatcher {
   */
   setup () {
     // setup all events notifications
-    this.setupElementEvents()
+    this.setupElementListeners()
     this.setupKeyboardEvents()
+    this.setupKeydownListener()
 
     if (selectionchange) {
-      this.setupSelectionChangeEvents()
+      this.setupSelectionChangeListeners()
     } else {
       this.setupSelectionChangeFallback()
     }
@@ -57,11 +59,9 @@ export default class Dispatcher {
   /**
   * Sets up events that are triggered on modifying an element.
   *
-  * @method setupElementEvents
-  * @param {HTMLElement} $document: The document element.
-  * @param {Function} notifier: The callback to be triggered when the event is caught.
+  * @method setupElementListeners
   */
-  setupElementEvents () {
+  setupElementListeners () {
     const self = this
     const selector = this.editableSelector
 
@@ -164,20 +164,28 @@ export default class Dispatcher {
   }
 
   /**
-  * Sets up events that are triggered on keyboard events.
-  * Keyboard definitions are in {{#crossLink "Keyboard"}}{{/crossLink}}.
+  * Sets up listener for keydown event which forwards events to
+  * the Keyboard instance.
   *
-  * @method setupKeyboardEvents
-  * @param {HTMLElement} $document: The document element.
-  * @param {Function} notifier: The callback to be triggered when the event is caught.
+  * @method setupKeydownListener
   */
-  setupKeyboardEvents () {
+  setupKeydownListener () {
     const self = this
 
     this.$document.on('keydown.editable', this.editableSelector, function (event) {
       const notifyCharacterEvent = !isInputEventSupported
       self.keyboard.dispatchKeyEvent(event, this, notifyCharacterEvent)
     })
+  }
+
+  /**
+  * Sets up handlers for the keyboard events.
+  * Keyboard definitions are in {{#crossLink "Keyboard"}}{{/crossLink}}.
+  *
+  * @method setupKeyboardEvents
+  */
+  setupKeyboardEvents () {
+    const self = this
 
     this.keyboard
       .on('left up', function (event) {
@@ -244,11 +252,11 @@ export default class Dispatcher {
   /**
   * Sets up events that are triggered on a selection change.
   *
-  * @method setupSelectionChangeEvents
+  * @method setupSelectionChangeListeners
   * @param {HTMLElement} $document: The document element.
   * @param {Function} notifier: The callback to be triggered when the event is caught.
   */
-  setupSelectionChangeEvents () {
+  setupSelectionChangeListeners () {
     let selectionDirty = false
     let suppressSelectionChanges = false
     const $document = this.$document

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -66,65 +66,64 @@ export default class Dispatcher {
     const selector = this.editableSelector
 
     this.$document
+      .on('focus.editable', selector, function (event) {
+        if (this.getAttribute(config.pastingAttribute)) return
+        self.notify('focus', this)
+      })
 
-    .on('focus.editable', selector, function (event) {
-      if (this.getAttribute(config.pastingAttribute)) return
-      self.notify('focus', this)
-    })
+      .on('blur.editable', selector, function (event) {
+        if (this.getAttribute(config.pastingAttribute)) return
+        self.notify('blur', this)
+      })
 
-    .on('blur.editable', selector, function (event) {
-      if (this.getAttribute(config.pastingAttribute)) return
-      self.notify('blur', this)
-    })
-
-    .on('copy.editable', selector, function (event) {
-      const selection = self.selectionWatcher.getFreshSelection()
-      if (selection.isSelection) {
-        self.notify('clipboard', this, 'copy', selection)
-      }
-    })
-
-    .on('cut.editable', selector, function (event) {
-      const selection = self.selectionWatcher.getFreshSelection()
-      if (selection.isSelection) {
-        self.notify('clipboard', this, 'cut', selection)
-        self.triggerChangeEvent(this)
-      }
-    })
-
-    .on('paste.editable', selector, function (event) {
-      const element = this
-
-      function afterPaste (blocks, cursor) {
-        if (blocks.length) {
-          self.notify('paste', element, blocks, cursor)
-
-          // The input event does not fire when we process the content manually
-          // and insert it via script
-          self.notify('change', element)
-        } else {
-          cursor.setVisibleSelection()
+      .on('copy.editable', selector, function (event) {
+        const selection = self.selectionWatcher.getFreshSelection()
+        if (selection.isSelection) {
+          self.notify('clipboard', this, 'copy', selection)
         }
-      }
+      })
 
-      const cursor = self.selectionWatcher.getFreshSelection()
-      clipboard.paste(this, cursor, afterPaste)
-    })
+      .on('cut.editable', selector, function (event) {
+        const selection = self.selectionWatcher.getFreshSelection()
+        if (selection.isSelection) {
+          self.notify('clipboard', this, 'cut', selection)
+          self.triggerChangeEvent(this)
+        }
+      })
 
-    .on('input.editable', selector, function (event) {
-      if (isInputEventSupported) {
+      .on('paste.editable', selector, function (event) {
+        const element = this
+
+        function afterPaste (blocks, cursor) {
+          if (blocks.length) {
+            self.notify('paste', element, blocks, cursor)
+
+            // The input event does not fire when we process the content manually
+            // and insert it via script
+            self.notify('change', element)
+          } else {
+            cursor.setVisibleSelection()
+          }
+        }
+
+        const cursor = self.selectionWatcher.getFreshSelection()
+        clipboard.paste(this, cursor, afterPaste)
+      })
+
+      .on('input.editable', selector, function (event) {
+        if (isInputEventSupported) {
+          self.notify('change', this)
+        } else {
+          // Most likely the event was already handled manually by
+          // triggerChangeEvent so the first time we just switch the
+          // isInputEventSupported flag without notifiying the change event.
+          isInputEventSupported = true
+        }
+      })
+
+      .on('formatEditable.editable', selector, function (event) {
         self.notify('change', this)
-      } else {
-        // Most likely the event was already handled manually by
-        // triggerChangeEvent so the first time we just switch the
-        // isInputEventSupported flag without notifiying the change event.
-        isInputEventSupported = true
-      }
-    })
-
-    .on('formatEditable.editable', selector, function (event) {
-      self.notify('change', this)
-    })
+      })
   }
 
   /**
@@ -181,66 +180,65 @@ export default class Dispatcher {
     })
 
     this.keyboard
+      .on('left up', function (event) {
+        self.dispatchSwitchEvent(event, this, 'before')
+      })
 
-    .on('left up', function (event) {
-      self.dispatchSwitchEvent(event, this, 'before')
-    })
+      .on('right down', function (event) {
+        self.dispatchSwitchEvent(event, this, 'after')
+      })
 
-    .on('right down', function (event) {
-      self.dispatchSwitchEvent(event, this, 'after')
-    })
+      .on('tab shiftTab esc', () => {})
 
-    .on('tab shiftTab esc', () => {})
+      .on('backspace', function (event) {
+        const range = self.selectionWatcher.getFreshRange()
+        if (!range.isCursor) return self.triggerChangeEvent(this)
 
-    .on('backspace', function (event) {
-      const range = self.selectionWatcher.getFreshRange()
-      if (!range.isCursor) return self.triggerChangeEvent(this)
+        const cursor = range.getCursor()
+        if (!cursor.isAtBeginning()) return self.triggerChangeEvent(this)
 
-      const cursor = range.getCursor()
-      if (!cursor.isAtBeginning()) return self.triggerChangeEvent(this)
+        event.preventDefault()
+        event.stopPropagation()
+        self.notify('merge', this, 'before', cursor)
+      })
 
-      event.preventDefault()
-      event.stopPropagation()
-      self.notify('merge', this, 'before', cursor)
-    })
+      .on('delete', function (event) {
+        const range = self.selectionWatcher.getFreshRange()
+        if (!range.isCursor) return self.triggerChangeEvent(this)
 
-    .on('delete', function (event) {
-      const range = self.selectionWatcher.getFreshRange()
-      if (!range.isCursor) return self.triggerChangeEvent(this)
+        const cursor = range.getCursor()
+        if (!cursor.isAtTextEnd()) return self.triggerChangeEvent(this)
 
-      const cursor = range.getCursor()
-      if (!cursor.isAtTextEnd()) return self.triggerChangeEvent(this)
+        event.preventDefault()
+        event.stopPropagation()
+        self.notify('merge', this, 'after', cursor)
+      })
 
-      event.preventDefault()
-      event.stopPropagation()
-      self.notify('merge', this, 'after', cursor)
-    })
+      .on('enter', function (event) {
+        event.preventDefault()
+        event.stopPropagation()
+        const range = self.selectionWatcher.getFreshRange()
+        const cursor = range.forceCursor()
 
-    .on('enter', function (event) {
-      event.preventDefault()
-      event.stopPropagation()
-      const range = self.selectionWatcher.getFreshRange()
-      const cursor = range.forceCursor()
+        if (cursor.isAtTextEnd()) {
+          self.notify('insert', this, 'after', cursor)
+        } else if (cursor.isAtBeginning()) {
+          self.notify('insert', this, 'before', cursor)
+        } else {
+          self.notify('split', this, cursor.before(), cursor.after(), cursor)
+        }
+      })
 
-      if (cursor.isAtTextEnd()) {
-        self.notify('insert', this, 'after', cursor)
-      } else if (cursor.isAtBeginning()) {
-        self.notify('insert', this, 'before', cursor)
-      } else {
-        self.notify('split', this, cursor.before(), cursor.after(), cursor)
-      }
-    })
+      .on('shiftEnter', function (event) {
+        event.preventDefault()
+        event.stopPropagation()
+        const cursor = self.selectionWatcher.forceCursor()
+        self.notify('newline', this, cursor)
+      })
 
-    .on('shiftEnter', function (event) {
-      event.preventDefault()
-      event.stopPropagation()
-      const cursor = self.selectionWatcher.forceCursor()
-      self.notify('newline', this, cursor)
-    })
-
-    .on('character', function (event) {
-      self.notify('change', this)
-    })
+      .on('character', function (event) {
+        self.notify('change', this)
+      })
   }
 
   /**


### PR DESCRIPTION
## Description

The methods `editable.suspend()` and `editable.continue` can be used to temporarily remove all event listeners. But the current implementation just removed the contenteditable attributes. All the other listeners were still active. This PR also removes all other event listeners when `suspend()` is called. So no more selection change events or copy/paste events are triggered when suspend() was called.