### PR TITLE
WIP Feat: VirtualSpan

### DIFF
--- a/src/contrib/virtual-span.js
+++ b/src/contrib/virtual-span.js
@@ -1,0 +1,152 @@
+import $ from 'jquery'
+import rangy from 'rangy'
+import { unwrap, adoptElement } from './content'
+
+function defaultMarkerConstructor (id, namespace) {
+  const marker = $('span')[0]
+  return marker
+}
+
+const defaultOptions = {
+  namespace: 'vspan',
+  idAttribute: 'data-vspan-id',
+  namespaceAttribute: 'data-vspan-namespace',
+  editableNamespace: 'vspan',
+  markerConstructor: defaultMarkerConstructor,
+  win: undefined
+}
+
+class VirtualSpan {
+  constructor ({
+    namespace,
+    idAttribute,
+    namespaceAttribute,
+    editableNamespace,
+    markerConstructor,
+    win
+  } = defaultOptions) {
+    this.namespace = namespace
+    this.idAttribute = idAttribute
+    this.namespaceAttribute = namespaceAttribute
+    this.editableNamespace = editableNamespace
+    this.markerConstructor = markerConstructor
+    this.win = win
+  }
+
+  extractRanges (host, markers) {
+    const range = rangy.createRange()
+    if (markers.length > 1) {
+      range.setStartBefore(markers.first()[0])
+      range.setEndAfter(markers.last()[0])
+    } else {
+      range.selectNode(markers[0])
+    }
+    return range.toCharacterRange(host)
+  }
+
+  getIdSelector (id) {
+    return `[${this.idAttribute}="${id}"]`
+  }
+
+  getIdAttrSelector () {
+    return `[${this.idAttribute}]`
+  }
+
+  createMarkerNode (id) {
+    let marker = this.markerConstructor(id, this.namespace)
+    if (this.win) {
+      marker = adoptElement(marker, this.win.document)
+    }
+    marker.setAttribute('data-editable', this.editableNamespace)
+    marker.setAttribute(this.idAttribute, id)
+    marker.setAttribute(this.namespaceAttribute, this.namespace)
+    return marker
+  }
+
+  insertIntoHost (host, id, startIndex, endIndex) {
+    const marker = this.createMarkerNode(id, this.namespace, this.win)
+    const range = rangy.createRange()
+    range.selectCharacters(host, startIndex, endIndex)
+    const fragment = range.extractContents()
+    marker.appendChild(fragment)
+    range.deleteContents()
+    range.insertNode(marker)
+  }
+
+  has (host, id) {
+    const matches = $(host).find(this.getIdSelector(id))
+    return !!matches.length
+  }
+
+  insert (host, id, startIndex, endIndex) {
+    if (this.has(host, id)) {
+      this.removeVSpan(host, id)
+    }
+    this.insertIntoHost(host, id, startIndex, endIndex)
+  }
+
+  remove (host, id) {
+    $(host)
+      .find(this.getIdSelector(id))
+      .each((index, elem) => {
+        unwrap(elem)
+      })
+  }
+
+  update (host, id, addCssClass, removeCssClass) {
+    if (!this.win || !this.win.document.documentElement.classList) return
+    $(host)
+      .find(this.getIdSelector(id))
+      .each((index, elem) => {
+        if (removeCssClass) elem.classList.remove(removeCssClass)
+        if (addCssClass) elem.classList.add(addCssClass)
+      })
+  }
+
+  getData (contentStr) {
+    const $host = $(`<div>${contentStr}</div>`)
+    const markers = $host.find(this.getIdAttrSelector())
+    if (!markers.length) {
+      return
+    }
+    const groups = {}
+    markers.each((_, marker) => {
+      const id = $(marker).attr(this.idAttribute)
+      if (!groups[id]) {
+        groups[id] = $host.find(this.getIdSelector(id))
+      }
+    })
+
+    const res = {}
+    Object.keys(groups).forEach(id => {
+      const position = this.extractRanges($host[0], groups[id])
+      const namespace = groups[id].attr(this.namespaceAttribute)
+      if (position) {
+        res[id] = {
+          ...position,
+          namespace
+        }
+      }
+    })
+    return res
+  }
+
+  applyData (contentStr, data) {
+    const $host = $(`<div>${contentStr}</div>`)
+
+    for (const id in data) {
+      const rangeData = data[id]
+      this.insertIntoHost($host[0], id, rangeData.start, rangeData.end)
+    }
+    return $host.html()
+  }
+
+  cleanUp (contentStr) {
+    const $host = $(`<div>${contentStr}</div>`)
+    const markers = $host.find(this.getIdAttrSelector())
+    $(markers).each((_, m) => unwrap(m))
+    return $host.html()
+  }
+}
+
+export default VirtualSpan

--- a/src/core.js
+++ b/src/core.js
@@ -13,6 +13,7 @@ import highlightSupport from './highlight-support'
 import Highlighting from './highlighting'
 import createDefaultEvents from './create-default-events'
 import browser from 'bowser'
+import VirtualSpan from './contrib/virtual-span'
 
 /**
  * The Core module provides the Editable class that defines the Editable.JS
@@ -401,6 +402,10 @@ const Editable = module.exports = class Editable {
 Editable.parser = parser
 Editable.content = content
 Editable.browser = browser
+
+Editable.Contrib = {
+  VirtualSpan
+}
 
 // Set up callback functions for several events.
 ;['focus', 'blur', 'flow', 'selection', 'cursor', 'newline',

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,12 +1,11 @@
 import 'rangy/lib/rangy-textrange'
-var $ = require('jquery')
+import $ from 'jquery'
 import Cursor from './cursor'
 import * as content from './content'
 import * as parser from './parser'
 import * as config from './config'
 import highlightSupport from './highlight-support'
 import highlightText from './highlight-text'
-
 /**
  * The Selection module provides a cross-browser abstraction layer for range
  * and selection.

--- a/src/selection.js
+++ b/src/selection.js
@@ -6,6 +6,7 @@ import * as parser from './parser'
 import * as config from './config'
 import highlightSupport from './highlight-support'
 import highlightText from './highlight-text'
+
 /**
  * The Selection module provides a cross-browser abstraction layer for range
  * and selection.
@@ -39,17 +40,14 @@ export default class Selection extends Cursor {
   }
 
   isAllSelected () {
-    return (
-      parser.isBeginningOfHost(
-        this.host,
-        this.range.startContainer,
-        this.range.startOffset
-      ) &&
-      parser.isTextEndOfHost(
-        this.host,
-        this.range.endContainer,
-        this.range.endOffset
-      )
+    return parser.isBeginningOfHost(
+      this.host,
+      this.range.startContainer,
+      this.range.startOffset
+    ) && parser.isTextEndOfHost(
+      this.host,
+      this.range.endContainer,
+      this.range.endOffset
     )
   }
 
@@ -65,10 +63,9 @@ export default class Selection extends Cursor {
     return this.range.nativeRange.getClientRects()
   }
 
+
   link (href, attrs = {}) {
-    const $link = $(
-      this.createElement(config.linkMarkup.name, config.linkMarkup.attribs)
-    )
+    const $link = $(this.createElement(config.linkMarkup.name, config.linkMarkup.attribs))
     if (href) attrs.href = href
     $link.attr(attrs)
     this.forceWrap($link[0])
@@ -94,7 +91,7 @@ export default class Selection extends Cursor {
 
   // Manually add a highlight
   // Note: the current code does not work with newlines (LP)
-  highlight ({ highlightId }) {
+  highlight ({highlightId}) {
     const textBefore = this.textBefore()
     const currentTextContent = this.text()
 
@@ -122,50 +119,32 @@ export default class Selection extends Cursor {
   }
 
   makeBold () {
-    const bold = this.createElement(
-      config.boldMarkup.name,
-      config.boldMarkup.attribs
-    )
+    const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
     this.forceWrap(bold)
   }
 
   toggleBold () {
-    const bold = this.createElement(
-      config.boldMarkup.name,
-      config.boldMarkup.attribs
-    )
+    const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
     this.toggle(bold)
   }
 
   giveEmphasis () {
-    const em = this.createElement(
-      config.italicMarkup.name,
-      config.italicMarkup.attribs
-    )
+    const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
     this.forceWrap(em)
   }
 
   toggleEmphasis () {
-    const em = this.createElement(
-      config.italicMarkup.name,
-      config.italicMarkup.attribs
-    )
+    const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
     this.toggle(em)
   }
 
   makeUnderline () {
-    const u = this.createElement(
-      config.underlineMarkup.name,
-      config.underlineMarkup.attribs
-    )
+    const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
     this.forceWrap(u)
   }
 
   toggleUnderline () {
-    const u = this.createElement(
-      config.underlineMarkup.name,
-      config.underlineMarkup.attribs
-    )
+    const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
     this.toggle(u)
   }
 
@@ -182,12 +161,7 @@ export default class Selection extends Cursor {
   // @param {String} E.g. '«'
   // @param {String} E.g. '»'
   surround (startCharacter, endCharacter) {
-    this.range = content.surround(
-      this.host,
-      this.range,
-      startCharacter,
-      endCharacter
-    )
+    this.range = content.surround(this.host, this.range, startCharacter, endCharacter)
     this.setSelection()
   }
 
@@ -198,10 +172,8 @@ export default class Selection extends Cursor {
   }
 
   toggleSurround (startCharacter, endCharacter) {
-    if (
-      this.containsString(startCharacter) &&
-      this.containsString(endCharacter)
-    ) {
+    if (this.containsString(startCharacter) &&
+    this.containsString(endCharacter)) {
       this.removeSurround(startCharacter, endCharacter)
     } else {
       this.surround(startCharacter, endCharacter)

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,5 +1,5 @@
-import $ from 'jquery'
-
+import 'rangy/lib/rangy-textrange'
+var $ = require('jquery')
 import Cursor from './cursor'
 import * as content from './content'
 import * as parser from './parser'
@@ -40,15 +40,22 @@ export default class Selection extends Cursor {
   }
 
   isAllSelected () {
-    return parser.isBeginningOfHost(
-      this.host,
-      this.range.startContainer,
-      this.range.startOffset
-    ) && parser.isTextEndOfHost(
-      this.host,
-      this.range.endContainer,
-      this.range.endOffset
+    return (
+      parser.isBeginningOfHost(
+        this.host,
+        this.range.startContainer,
+        this.range.startOffset
+      ) &&
+      parser.isTextEndOfHost(
+        this.host,
+        this.range.endContainer,
+        this.range.endOffset
+      )
     )
+  }
+
+  getTextRange () {
+    return this.range.toCharacterRange(this.host)
   }
 
   // Get the ClientRects of this selection.
@@ -59,9 +66,10 @@ export default class Selection extends Cursor {
     return this.range.nativeRange.getClientRects()
   }
 
-
   link (href, attrs = {}) {
-    const $link = $(this.createElement(config.linkMarkup.name, config.linkMarkup.attribs))
+    const $link = $(
+      this.createElement(config.linkMarkup.name, config.linkMarkup.attribs)
+    )
     if (href) attrs.href = href
     $link.attr(attrs)
     this.forceWrap($link[0])
@@ -87,7 +95,7 @@ export default class Selection extends Cursor {
 
   // Manually add a highlight
   // Note: the current code does not work with newlines (LP)
-  highlight ({highlightId}) {
+  highlight ({ highlightId }) {
     const textBefore = this.textBefore()
     const currentTextContent = this.text()
 
@@ -115,32 +123,50 @@ export default class Selection extends Cursor {
   }
 
   makeBold () {
-    const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
+    const bold = this.createElement(
+      config.boldMarkup.name,
+      config.boldMarkup.attribs
+    )
     this.forceWrap(bold)
   }
 
   toggleBold () {
-    const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
+    const bold = this.createElement(
+      config.boldMarkup.name,
+      config.boldMarkup.attribs
+    )
     this.toggle(bold)
   }
 
   giveEmphasis () {
-    const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
+    const em = this.createElement(
+      config.italicMarkup.name,
+      config.italicMarkup.attribs
+    )
     this.forceWrap(em)
   }
 
   toggleEmphasis () {
-    const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
+    const em = this.createElement(
+      config.italicMarkup.name,
+      config.italicMarkup.attribs
+    )
     this.toggle(em)
   }
 
   makeUnderline () {
-    const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
+    const u = this.createElement(
+      config.underlineMarkup.name,
+      config.underlineMarkup.attribs
+    )
     this.forceWrap(u)
   }
 
   toggleUnderline () {
-    const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
+    const u = this.createElement(
+      config.underlineMarkup.name,
+      config.underlineMarkup.attribs
+    )
     this.toggle(u)
   }
 
@@ -157,7 +183,12 @@ export default class Selection extends Cursor {
   // @param {String} E.g. '«'
   // @param {String} E.g. '»'
   surround (startCharacter, endCharacter) {
-    this.range = content.surround(this.host, this.range, startCharacter, endCharacter)
+    this.range = content.surround(
+      this.host,
+      this.range,
+      startCharacter,
+      endCharacter
+    )
     this.setSelection()
   }
 
@@ -168,8 +199,10 @@ export default class Selection extends Cursor {
   }
 
   toggleSurround (startCharacter, endCharacter) {
-    if (this.containsString(startCharacter) &&
-    this.containsString(endCharacter)) {
+    if (
+      this.containsString(startCharacter) &&
+      this.containsString(endCharacter)
+    ) {
       this.removeSurround(startCharacter, endCharacter)
     } else {
       this.surround(startCharacter, endCharacter)


### PR DESCRIPTION
Relations:
  - Issues: 
      - livingdocsIO/livingdocs-planning#2472
      - livingdocsIO/livingdocs-planning#2473
  - PR's:
      - livingdocsIO/livingdocs-framework#381 
      - livingdocsIO/livingdocs-editor#2639


### Changelog
* Added rangy's [TextRange module](https://github.com/timdown/rangy/wiki/Text-Range-Module), mainly because of its `toCharacterRange` method. Exposed as `Selection#getTextRange`.

##### `VirtualSpan`
A class that helps with handling partials in text, which have a visual representation but are not considered part of the actual document. It turned out to be independent of a running Editable instance, that's why I made it part of a new `contrib` namespace. 
Its first use case would be comments in documents.

It exposes two kind of methods:
1. Helpers to insert, remove and update the DOM representations of a given set of virtual spans. Operates on the DOM. (See livingdocsIO/livingdocs-editor#2639)
2. Helpers to remove  and reapply said virtual spans from a given content *string*. (See livingdocsIO/livingdocs-framework#381)

The idea is to use the first set of methods to attach and remove virtual spans to the DOM and the second set to guarantee data consistency on a model level. 

The main motivation behind not having those virtual spans have the `ui-unwrap` directive and consequentially being removed and reapplied on every update (as I tried here livingdocsIO/editable.js#164) is that those virtual spans somewhat have to live in each components markup. They are expected to behave like any other inline tag (eg `<strong>`) and treating them as some extraneous entity felt like preventing editable from being editable while reimplementing its core features for the most parts.

It's a little unorthodox, but it's playing to the general strengths of this lib in a way that no other solution could (at least those I was able to come up with). And it's very contained and can easily be added/removed when needed.   

### Known issues

* Formatting a selection that includes a comment edge will remove any virtual span in the editable container aka *nuke* issue

## Pull Request Checklist
- [ ] Tests