### PR TITLE
Clipboard: Copy&Paste keeps links relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma-safari-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
+    "lodash.clonedeep": "^4.5.0",
     "normalize.css": "^4.1.1",
     "open-browser-webpack-plugin": "0.0.2",
     "prismjs": "^1.4.1",

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -1,4 +1,5 @@
-import { parseContent } from '../src/clipboard'
+import { parseContent, updateConfig } from '../src/clipboard'
+import * as config from '../src/config'
 
 describe('Clipboard', () => {
   describe('parseContent()', () => {
@@ -141,6 +142,13 @@ describe('Clipboard', () => {
         </p>`
 
       expect(parseContent(div)[0]).toEqual('bar')
+    })
+
+    it('keeps internal links of a anchorTag with an href attribute', () => {
+      expect(extractSingleBlock('<a href="http://localhost:9876/test123">a</a>')).toEqual('<a href="http://localhost:9876/test123">a</a>')
+      config.pastedHtmlRules.keepInternalRelativeLinks = true
+      updateConfig(config)
+      expect(extractSingleBlock('<a href="http://localhost:9876/test123">a</a>')).toEqual('<a href="/test123">a</a>')
     })
   })
 })

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -92,7 +92,7 @@ export function filterHtmlElements (elem) {
 
     // Keep internal relative links relative (on paste).
     if (keepInternalRelativeLinks && child.nodeName === 'A' && child.href) {
-      const stripInternalHost = child.href.replace(window.location.origin, '')
+      const stripInternalHost = child.getAttribute('href').replace(window.location.origin, '')
       child.setAttribute('href', stripInternalHost)
     }
 
@@ -112,7 +112,7 @@ export function conditionalNodeWrap (child, content) {
   nodeName = transformNodeName(nodeName)
 
   if (shouldKeepNode(nodeName, child)) {
-    var attributes = filterAttributes(nodeName, child)
+    const attributes = filterAttributes(nodeName, child)
 
     if (nodeName === 'br') return `<${nodeName + attributes}>`
 
@@ -134,10 +134,11 @@ export function conditionalNodeWrap (child, content) {
   return content
 }
 
+// returns string of concatenated attributes e.g. 'target="_blank" rel="nofollow" href="/test.com"'
 export function filterAttributes (nodeName, node) {
-  return Array.from(node.attributes).reduce((attributes, {name, value}) => {
-    if ((allowedElements[nodeName][name]) && value) {
-      return ` ${name}="${value}"`
+  return Array.from(node.attributes).reduce((attributes, { name, value }) => {
+    if (allowedElements[nodeName][name] && value) {
+      return `${attributes} ${name}="${value}"`
     }
     return attributes
   }, '')

--- a/src/config.js
+++ b/src/config.js
@@ -38,7 +38,9 @@ export const pastedHtmlRules = {
   // to get rid of a whole element (tag+content)
   allowedElements: {
     'a': {
-      'href': true
+      'href': true,
+      'rel': true,
+      'target': true
     },
     'strong': {},
     'em': {},

--- a/src/config.js
+++ b/src/config.js
@@ -70,5 +70,7 @@ export const pastedHtmlRules = {
 
   // A list of elements that will get completly removed when pasted. Their tags
   // and content (text content and child elements) will get removed.
-  blacklistedElements: ['style', 'script']
+  blacklistedElements: ['style', 'script'],
+
+  keepInternalRelativeLinks: false
 }


### PR DESCRIPTION
Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/2965
  - Issue2: https://github.com/livingdocsIO/livingdocs-planning/issues/3025
## Description
The clipboard turns relative links into absolute ones so:
`/internal/link` gets converted to `https://livingdocs.io/internal/link`

There is a new flag to turn off this behavior if the link was copied from the same context/host editable is running on.

So if a relative link was copied from `https://livingdocs.io/internal/link` it strips off the protocol, hostname and port number of a URL and turns it to `/internal/link`
If a relative link was copied from `https://somewebpage.com/internal/link` it will still convert it to an absolute one.

## Changelog
- new config option
```js
Editable.globalConfig({
 pastedHtmlRules: {
  keepInternalRelativeLinks: true || false // default false
 }
}
```

## Test Instructions
Create an article.
Add a text with a relative link like /link.
Copy the text and past to another component.
Check the link.