### PR TITLE
Add helper to retrieve the editable configs

### DIFF
--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -40,7 +40,6 @@ describe('Clipboard', () => {
 
     it('keeps a <a> element with an a list of whitelisted-attributes', () => {
       const updatedConfig = cloneDeep(config)
-      console.log(updatedConfig)
       updatedConfig.pastedHtmlRules.allowedElements = { a: { href: true, rel: true, target: true } }
 
       updateConfig(updatedConfig)
@@ -162,7 +161,6 @@ describe('Clipboard', () => {
     it('changes absolute links to relative ones with the keepInternalRelativeLinks flag set to true', () => {
       const updatedConfig = cloneDeep(config)
       updatedConfig.pastedHtmlRules.keepInternalRelativeLinks = true
-      console.log(updatedConfig)
       updateConfig(updatedConfig)
       expect(extractSingleBlock(`<a href="${window.location.origin}/test123">a</a>`)).toEqual('<a href="/test123">a</a>')
     })

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -39,6 +39,18 @@ describe('Editable configuration', () => {
       Editable.globalConfig(originalConfig)
     })
 
+    it('retreives the default config', () => {
+      expect(originalConfig).toEqual(Editable.getGlobalConfig())
+    })
+
+    it('retrieves the default config after changes to the globalConfig', () => {
+      Editable.globalConfig({
+        editableClass: 'editable-instance'
+      })
+
+      expect(originalConfig).not.toEqual(Editable.getGlobalConfig())
+    })
+
     it('has a default value for "editableClass"', () => {
       expect(config.editableClass).toEqual('js-editable')
     })

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -39,11 +39,11 @@ describe('Editable configuration', () => {
       Editable.globalConfig(originalConfig)
     })
 
-    it('retreives the default config', () => {
+    it('retreives the config', () => {
       expect(originalConfig).toEqual(Editable.getGlobalConfig())
     })
 
-    it('retrieves the default config after changes to the globalConfig', () => {
+    it('retrieves the current state of the config', () => {
       Editable.globalConfig({
         editableClass: 'editable-instance'
       })

--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -275,8 +275,6 @@ le Make The <br> World Go Round`)
 <span class="highlight-comment" data-word-id="first" data-editable="ui-unwrap" data-highlight="comment">a</span>
 ke The <br> World Go Round`)
 
-      console.log(expectedHtml)
-
       expect(this.extract()).toEqual(expectedRanges)
       expect(this.getHtml()).toEqual(expectedHtml)
     })

--- a/spec/spellcheck.spec.js
+++ b/spec/spellcheck.spec.js
@@ -63,7 +63,7 @@ describe('Spellcheck:', function () {
         this.errors = []
 
         this.highlighting.highlight(this.p)
-        // console.log('this.p.outerHTML', this.p.outerHTML)
+
         $misspelledWord = $(this.p).find('.misspelled-word')
         expect($misspelledWord.length).toEqual(0)
       })

--- a/src/core.js
+++ b/src/core.js
@@ -59,6 +59,13 @@ const Editable = module.exports = class Editable {
   }
 
   /**
+   * @returns the default Editable configs from config.js
+   */
+  static getGlobalConfig () {
+    return config
+  }
+
+  /**
   * Set configuration options that affect all editable
   * instances.
   *


### PR DESCRIPTION
### Description
Instead of resorting to using a deep-require - a simple helper to retrieve the Editable standard configs.

### Changelog
- Adds `Editable.getGlobalConfig()`to retrieve the current state of the configs