### PR TITLE
Shift enter at end of text adds data tag to the added <br> tag

### DIFF
--- a/spec/cursor.spec.js
+++ b/spec/cursor.spec.js
@@ -53,6 +53,12 @@ describe('Cursor', function () {
       })
     })
 
+    describe('isAtEnd()', () => {
+      it('is true', () => {
+        expect(this.cursor.isAtTextEnd()).toBe(true)
+      })
+    })
+
     describe('isAtBeginning()', () => {
       it('is false', () => {
         expect(this.cursor.isAtBeginning()).toBe(false)
@@ -66,6 +72,7 @@ describe('Cursor', function () {
         // move the cursor so we can check the restore method.
         this.cursor.moveAtBeginning()
         expect(this.cursor.isAtBeginning()).toBe(true)
+        expect(this.cursor.isAtTextEnd()).toBe(false)
 
         this.cursor.restore()
         expect(this.cursor.isAtEnd()).toBe(true)

--- a/spec/cursor.spec.js
+++ b/spec/cursor.spec.js
@@ -47,8 +47,8 @@ describe('Cursor', function () {
       expect(this.range.endOffset).toEqual(1)
     })
 
-    describe('isAtEnd()', () => {
-      it('is true', () => {
+    describe('isAtTextEnd()', () => {
+      it('returns true when at text end', () => {
         expect(this.cursor.isAtEnd()).toBe(true)
       })
     })

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -195,5 +195,18 @@ describe('Dispatcher', () => {
         $elem.trigger(event)
       })
     })
+
+    describe('on newline', () => {
+      beforeEach(() => {
+        event = $.Event('keydown')
+        event.shiftKey = true
+        event.keyCode = 13
+      })
+
+      it('fires newline when shift + enter is pressed', (done) => {
+        on('newline', done)
+        $elem.trigger(event)
+      })
+    })
   })
 })

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -55,7 +55,9 @@ export default function createDefaultBehavior (editable) {
         trailingBr.setAttribute('data-editable', 'remove')
         cursor.insertBefore(trailingBr)
       } else {
-        cursor.insertBefore(document.createElement('br'))
+        const trailingBr = document.createElement('br')
+        trailingBr.setAttribute('data-editable', 'newline')
+        cursor.insertBefore(trailingBr)
       }
 
       cursor.setVisibleSelection()

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -48,19 +48,14 @@ export default function createDefaultBehavior (editable) {
     },
 
     newline (element, cursor) {
-      cursor.insertBefore(document.createElement('br'))
 
-      if (cursor.isAtEnd()) {
-        log('at the end')
 
-        const noWidthSpace = document.createTextNode('\u200B')
-        cursor.insertAfter(noWidthSpace)
-
-        // var trailingBr = document.createElement('br')
-        // trailingBr.setAttribute('type', '-editablejs')
-        // cursor.insertAfter(trailingBr)
+      if (cursor.isAtTextEnd()) {
+        const trailingBr = document.createElement('br')
+        trailingBr.setAttribute('data-editable', 'remove')
+        cursor.insertBefore(trailingBr)
       } else {
-        log('not at the end')
+        cursor.insertBefore(document.createElement('br'))
       }
 
       cursor.setVisibleSelection()

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -49,15 +49,12 @@ export default function createDefaultBehavior (editable) {
 
     newline (element, cursor) {
 
-
       if (cursor.isAtTextEnd()) {
         const trailingBr = document.createElement('br')
         trailingBr.setAttribute('data-editable', 'remove')
         cursor.insertBefore(trailingBr)
       } else {
-        const trailingBr = document.createElement('br')
-        trailingBr.setAttribute('data-editable', 'newline')
-        cursor.insertBefore(trailingBr)
+        cursor.insertBefore(document.createElement('br'))
       }
 
       cursor.setVisibleSelection()


### PR DESCRIPTION
### Description
We're fighting against default browser behavior here as adding a break-tag with shift+enter at the end of a text, will automatically create two break-tags, with one being un-deletable.

Related issue that tinymc has (They have a WYSIWYG-editor): https://github.com/tinymce/tinymce/issues/4856

My suggestion is to just intervene and disallow/remove break-tags at the end of a text. This is more transparent due to the visual feedback, vs hidden `<br>` tags in the document.

Furthermore, mark all other break-tags (`<br data-editable="newline">`), because this solution has some tradeoffs as well.

### Changelog
- Shift+enter at the end of a line will now add `<br data-editable="remove">` instead of `<br>`
- Shift+enter now marks all the break-tags `<br data-editable="newline">`

### Tradeoffs
- When creating a new line with shift+enter in the middle of a text, then deleting everything after the soft-break, will result in an undeletable break-tag again.
-> Those would be manually filterable `<br data-editable="newline">` scanning for that.