### PR TITLE
handling exception in getSelection

### DIFF
--- a/src/selection-watcher.js
+++ b/src/selection-watcher.js
@@ -24,9 +24,17 @@ export default class SelectionWatcher {
 
   /**
    * Updates the internal selection pointer to the current rangy selection.
+   * Returns true if no exception occured.
    */
   syncSelection () {
-    this.rangySelection = rangy.getSelection(this.win)
+    // it is possible that rangy has a problem with the nativeSelection
+    try {
+      this.rangySelection = rangy.getSelection(this.win)
+    } catch (err) {
+      return false
+    }
+
+    return true
   }
 
   /**
@@ -34,12 +42,12 @@ export default class SelectionWatcher {
   * otherwise return an empty RangeContainer
   */
   getRangeContainer () {
-    this.syncSelection()
+    const successfulSync = this.syncSelection()
 
     // rangeCount is 0 or 1 in all browsers except firefox
     // firefox can work with multiple ranges
     // (on a mac hold down the command key to select multiple ranges)
-    if (this.rangySelection.rangeCount) {
+    if (this.rangySelection.rangeCount && successfulSync) {
       const range = this.rangySelection.getRangeAt(0)
       const hostNode = parser.getHost(range.commonAncestorContainer)
       if (hostNode) return new RangeContainer(hostNode, range)


### PR DESCRIPTION
# Description
Rangy can throw in some cases an exception on the getSelection because the nativeSelection is not available.

```TypeError: Cannot read property 'rangeCount' of null
    at refreshSelection (VM42172 rangy-core.js:3428)
    at WrappedSelection.selProto.refresh (VM42172 rangy-core.js:3462)
    at Object.getSelection (VM42172 rangy-core.js:3223)
    at SelectionWatcher.syncSelection (VM42222 selection-watcher.js:83)
    at SelectionWatcher.getRangeContainer (VM42222 selection-watcher.js:93)
    at SelectionWatcher.getFreshSelection (VM42222 selection-watcher.js:127)
    at Editable.getSelection (VM42151 core.js:365)
    at Highlighting.safeHighlightMatches (VM42272 highlighting.js:217)
    at eval (VM42272 highlighting.js:207)
    at eval (VM42273 spellcheck-service.js:64) "Possibly unhandled rejection: {}"
```

# Changelog
- catch rangy exception and return empty RangeContainer