### PR TITLE
Allow listening multiple event types

### DIFF
--- a/src/eventable.js
+++ b/src/eventable.js
@@ -54,7 +54,7 @@ function getEventableModule (notifyContext) {
   return {
     on (event, listener) {
       if (arguments.length === 2) {
-        addListener(event, listener)
+        for (let eventType of event.split(' ')) addListener(eventType, listener)
       } else if (arguments.length === 1) {
         for (let eventType in event) addListener(eventType, event[eventType])
       }


### PR DESCRIPTION
Allow to use eventable.on to listen multiple event types with the
same listener. 

Keyboard.on is called with multiple event types in dispatcher.js, so this fixes issue #161.
https://github.com/livingdocsIO/editable.js/blob/4b264b8cc15af9160cfa32b8ed8a088aae164553/src/dispatcher.js#L207-L216