### PR TITLE
add custom elements and 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4633,6 +4633,12 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -4780,10 +4786,13 @@
       "dev": true
     },
     "is-wsl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -5103,9 +5112,9 @@
       }
     },
     "karma-firefox-launcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.2.0.tgz",
-      "integrity": "sha512-j9Zp8M8+VLq1nI/5xZGfzeaEPtGQ/vk3G+Y8vpmFWLvKLNZ2TDjD6cu2dUu7lDbu1HXNgatsAX4jgCZTkR9qhQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.3.0.tgz",
+      "integrity": "sha512-Fi7xPhwrRgr+94BnHX0F5dCl1miIW4RHnzjIGxF8GaIEp7rNqX7LSi7ok63VXs3PS/5MQaQMhGxw+bvD+pibBQ==",
       "dev": true,
       "requires": {
         "is-wsl": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.0.0",
-    "karma-firefox-launcher": "^1.0.0",
+    "karma-firefox-launcher": "^1.3.0",
     "karma-jasmine": "^1.0.2",
     "karma-safari-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -169,6 +169,38 @@ describe('Content', () => {
     })
   })
 
+  describe('getTagsByNameAndAttributes()', () => {
+    let range
+    beforeEach(() => {
+      range = rangy.createRange()
+    })
+
+    it('filters tag with attributes match', () => {
+      const test = $('<div><span class="foo"><span class="test">a</span></span></div>')
+      range.setStart(test[0], 0)
+      range.setEnd(test[0], 1)
+      const tags = content.getTagsByNameAndAttributes(test[0], range, $('<span class="foo">')[0])
+      expect(content.getTagNames(tags)).toEqual(['SPAN'])
+    })
+
+    it('filters tag with attributes match', () => {
+      const test = $('<div><span class="foo"><span class="foo">a</span></span></div>')
+      range.setStart(test[0], 0)
+      range.setEnd(test[0], 1)
+      const tags = content.getTagsByNameAndAttributes(test[0], range, $('<span class="foo">')[0])
+      expect(content.getTagNames(tags)).toEqual(['SPAN', 'SPAN'])
+    })
+
+    it('filters inner tags', () => {
+      // <div>|<span class="foo"><span class="test">a</span></span>|</div>
+      const test = $('<div><span class="foo"><span class="test">a</span></span></div>')
+      range.setStart(test[0], 0)
+      range.setEnd(test[0], 1)
+      const tags = content.getTagsByNameAndAttributes(test[0], range, $('<span class="foo">')[0])
+      expect(content.getTagNames(tags)).toEqual(['SPAN'])
+    })
+  })
+
   describe('wrap()', () => {
     let range
 

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -6,8 +6,8 @@ import * as rangeSaveRestore from '../src/range-save-restore'
 
 rangy.init()
 
-describe('Content', () => {
-  describe('normalizeTags()', () => {
+describe('Content', function () {
+  describe('normalizeTags()', function () {
     const plain = $('<div>Plain <strong>text</strong><strong>block</strong> example snippet</div>')[0]
     const plainWithSpace = $('<div>Plain <strong>text</strong> <strong>block</strong> example snippet</div>')[0]
     const nested = $('<div>Nested <strong><em>text</em></strong><strong><em>block</em></strong> example snippet</div>')[0]
@@ -15,42 +15,42 @@ describe('Content', () => {
     const consecutiveNewLines = $('<div>Consecutive<br><br>new lines</div>')[0]
     const emptyTags = $('<div>Example with <strong>empty <em></em>nested</strong><br>tags</div>')[0]
 
-    it('works with plain block', () => {
+    it('works with plain block', function () {
       const expected = $('<div>Plain <strong>textblock</strong> example snippet</div>')[0]
       const actual = plain.cloneNode(true)
       content.normalizeTags(actual)
       expect(actual.innerHTML).toEqual(expected.innerHTML)
     })
 
-    it('does not merge tags if not consecutives', () => {
+    it('does not merge tags if not consecutives', function () {
       const expected = plainWithSpace.cloneNode(true)
       const actual = plainWithSpace.cloneNode(true)
       content.normalizeTags(actual)
       expect(actual.innerHTML).toEqual(expected.innerHTML)
     })
 
-    it('works with nested blocks', () => {
+    it('works with nested blocks', function () {
       const expected = $('<div>Nested <strong><em>textblock</em></strong> example snippet</div>')[0]
       const actual = nested.cloneNode(true)
       content.normalizeTags(actual)
       expect(actual.innerHTML).toEqual(expected.innerHTML)
     })
 
-    it('works with nested blocks that mix other tags', () => {
+    it('works with nested blocks that mix other tags', function () {
       const expected = $('<div>Nested <strong>and mixed <em>textblock</em> <em>examples</em></strong> snippet</div>')[0]
       const actual = nestedMixed.cloneNode(true)
       content.normalizeTags(actual)
       expect(actual.innerHTML).toEqual(expected.innerHTML)
     })
 
-    it('does not merge consecutive new lines', () => {
+    it('does not merge consecutive new lines', function () {
       const expected = consecutiveNewLines.cloneNode(true)
       const actual = consecutiveNewLines.cloneNode(true)
       content.normalizeTags(actual)
       expect(actual.innerHTML).toEqual(expected.innerHTML)
     })
 
-    it('should remove empty tags and preserve new lines', () => {
+    it('should remove empty tags and preserve new lines', function () {
       const expected = $('<div>Example with <strong>empty nested</strong><br>tags</div>')[0]
       const actual = emptyTags.cloneNode(true)
       content.normalizeTags(actual)
@@ -59,11 +59,11 @@ describe('Content', () => {
   })
 
   describe('normalizeWhitespace()', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       this.element = $('<div></div>')[0]
     })
 
-    it('replaces whitespace with spaces', () => {
+    it('replaces whitespace with spaces', function () {
       this.element.innerHTML = '&nbsp; \ufeff'
       let text = this.element.textContent
 
@@ -75,40 +75,39 @@ describe('Content', () => {
     })
   })
 
-  describe('getInnerTags()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('getInnerTags()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('works with partially selected <strong><em>', () => {
+    it('works with partially selected <strong><em>', function () {
       // <div>|a <strong><em>b|</em></strong> c</div>
       const test = $('<div>a <strong><em>b</em></strong> c</div>')
-      range.setStart(test[0], 0)
-      range.setEnd(test.find('em')[0], 1)
-      const tags = content.getInnerTags(range)
+      this.range.setStart(test[0], 0)
+      this.range.setEnd(test.find('em')[0], 1)
+      const tags = content.getInnerTags(this.range)
       expect(content.getTagNames(tags)).toEqual(['STRONG', 'EM'])
     })
 
-    it('gets nothing inside a <b>', () => {
+    it('gets nothing inside a <b>', function () {
       // <div><b>|a|</b></div>
       const test = $('<div><b>a</b></div>')
-      range.setStart(test.find('b')[0], 0)
-      range.setEnd(test.find('b')[0], 1)
-      const tags = content.getInnerTags(range)
+      this.range.setStart(test.find('b')[0], 0)
+      this.range.setEnd(test.find('b')[0], 1)
+      const tags = content.getInnerTags(this.range)
       expect(content.getTagNames(tags)).toEqual([])
     })
 
-    it('gets a fully surrounded <b>', () => {
+    it('gets a fully surrounded <b>', function () {
       // <div>|<b>a</b>|</div>
       const test = $('<div><b>a</b></div>')
-      range.setStart(test[0], 0)
-      range.setEnd(test[0], 1)
-      const tags = content.getInnerTags(range)
+      this.range.setStart(test[0], 0)
+      this.range.setEnd(test[0], 1)
+      const tags = content.getInnerTags(this.range)
       expect(content.getTagNames(tags)).toEqual(['B'])
     })
 
-    it('gets partially selected <b> and <i>', () => {
+    it('gets partially selected <b> and <i>', function () {
       // <div><b>a|b</b><i>c|d</i></div>
       const test = $('<div><b>ab</b><i>cd</i></div>')
       const range = rangy.createRange()
@@ -119,176 +118,168 @@ describe('Content', () => {
     })
   })
 
-  describe('getTags()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('getTags()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('inside <b>', () => {
+    it('inside <b>', function () {
       // <div><b>|a|</b></div>
       const test = $('<div><b>a</b></div>')
-      range.setStart(test.find('b')[0], 0)
-      range.setEnd(test.find('b')[0], 1)
-      const tags = content.getTags(test[0], range)
+      this.range.setStart(test.find('b')[0], 0)
+      this.range.setEnd(test.find('b')[0], 1)
+      const tags = content.getTags(test[0], this.range)
       expect(content.getTagNames(tags)).toEqual(['B'])
     })
 
-    it('insde <em><b>', () => {
+    it('insde <em><b>', function () {
       // <div><i><b>|a|</b></i></div>
       const test = $('<div><i><b>a</b></i></div>')
-      range.setStart(test.find('b')[0], 0)
-      range.setEnd(test.find('b')[0], 1)
-      const tags = content.getTags(test[0], range)
+      this.range.setStart(test.find('b')[0], 0)
+      this.range.setEnd(test.find('b')[0], 1)
+      const tags = content.getTags(test[0], this.range)
       expect(content.getTagNames(tags)).toEqual(['B', 'I'])
     })
   })
 
-  describe('getTagsByName()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('getTagsByName()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('filters outer tags', () => {
+    it('filters outer tags', function () {
       // <div><i><b>|a|</b></i></div>
       const test = $('<div><i><b>a</b></i></div>')
-      range.setStart(test.find('b')[0], 0)
-      range.setEnd(test.find('b')[0], 1)
-      const tags = content.getTagsByName(test[0], range, 'b')
+      this.range.setStart(test.find('b')[0], 0)
+      this.range.setEnd(test.find('b')[0], 1)
+      const tags = content.getTagsByName(test[0], this.range, 'b')
       expect(content.getTagNames(tags)).toEqual(['B'])
     })
 
-    it('filters inner tags', () => {
+    it('filters inner tags', function () {
       // <div>|<i><b>a</b></i>|</div>
       const test = $('<div><i><b>a</b></i></div>')
-      range.setStart(test[0], 0)
-      range.setEnd(test[0], 1)
-      const tags = content.getTagsByName(test[0], range, 'i')
+      this.range.setStart(test[0], 0)
+      this.range.setEnd(test[0], 1)
+      const tags = content.getTagsByName(test[0], this.range, 'i')
       expect(content.getTagNames(tags)).toEqual(['I'])
     })
   })
 
-  describe('getTagsByNameAndAttributes()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('getTagsByNameAndAttributes()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('filters tag with attributes match', () => {
+    it('filters tag with attributes match', function () {
       const test = $('<div><span class="foo"><span class="test">a</span></span></div>')
-      range.setStart(test[0], 0)
-      range.setEnd(test[0], 1)
-      const tags = content.getTagsByNameAndAttributes(test[0], range, $('<span class="foo">')[0])
+      this.range.setStart(test[0], 0)
+      this.range.setEnd(test[0], 1)
+      const tags = content.getTagsByNameAndAttributes(test[0], this.range, $('<span class="foo">')[0])
       expect(content.getTagNames(tags)).toEqual(['SPAN'])
     })
 
-    it('filters tag with attributes match', () => {
+    it('filters tag with attributes match', function () {
       const test = $('<div><span class="foo"><span class="foo">a</span></span></div>')
-      range.setStart(test[0], 0)
-      range.setEnd(test[0], 1)
-      const tags = content.getTagsByNameAndAttributes(test[0], range, $('<span class="foo">')[0])
+      this.range.setStart(test[0], 0)
+      this.range.setEnd(test[0], 1)
+      const tags = content.getTagsByNameAndAttributes(test[0], this.range, $('<span class="foo">')[0])
       expect(content.getTagNames(tags)).toEqual(['SPAN', 'SPAN'])
     })
 
-    it('filters inner tags', () => {
+    it('filters inner tags', function () {
       // <div>|<span class="foo"><span class="test">a</span></span>|</div>
       const test = $('<div><span class="foo"><span class="test">a</span></span></div>')
-      range.setStart(test[0], 0)
-      range.setEnd(test[0], 1)
-      const tags = content.getTagsByNameAndAttributes(test[0], range, $('<span class="foo">')[0])
+      this.range.setStart(test[0], 0)
+      this.range.setEnd(test[0], 1)
+      const tags = content.getTagsByNameAndAttributes(test[0], this.range, $('<span class="foo">')[0])
       expect(content.getTagNames(tags)).toEqual(['SPAN'])
     })
   })
 
-  describe('wrap()', () => {
-    let range
-
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('wrap()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('creates an <em>', () => {
+    it('creates an <em>', function () {
       // <div>|b|</div>
       const host = $('<div>b</div>')
-      range.setStart(host[0], 0)
-      range.setEnd(host[0], 1)
+      this.range.setStart(host[0], 0)
+      this.range.setEnd(host[0], 1)
 
-      content.wrap(range, '<em>')
+      content.wrap(this.range, '<em>')
       expect(host.html()).toEqual('<em>b</em>')
     })
   })
 
-  describe('isAffectedBy()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('isAffectedBy()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('detects a <b> tag', () => {
+    it('detects a <b> tag', function () {
       // <div><b>|a|</b></div>
       const host = $('<div><b>a</b></div>')
-      range.setStart(host.find('b')[0], 0)
-      range.setEnd(host.find('b')[0], 1)
+      this.range.setStart(host.find('b')[0], 0)
+      this.range.setEnd(host.find('b')[0], 1)
 
-      expect(content.isAffectedBy(host[0], range, 'b')).toEqual(true)
-      expect(content.isAffectedBy(host[0], range, 'strong')).toEqual(false)
+      expect(content.isAffectedBy(host[0], this.range, 'b')).toEqual(true)
+      expect(content.isAffectedBy(host[0], this.range, 'strong')).toEqual(false)
     })
   })
 
-  describe('containsString()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('containsString()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('finds a character in the range', () => {
+    it('finds a character in the this.range', function () {
       // <div>|ab|c</div>
       const host = $('<div>abc</div>')
-      range.setStart(host[0].firstChild, 0)
-      range.setEnd(host[0].firstChild, 2)
+      this.range.setStart(host[0].firstChild, 0)
+      this.range.setEnd(host[0].firstChild, 2)
 
-      expect(content.containsString(range, 'a')).toEqual(true)
-      expect(content.containsString(range, 'b')).toEqual(true)
-      expect(content.containsString(range, 'c')).toEqual(false)
+      expect(content.containsString(this.range, 'a')).toEqual(true)
+      expect(content.containsString(this.range, 'b')).toEqual(true)
+      expect(content.containsString(this.range, 'c')).toEqual(false)
     })
   })
 
-  describe('deleteCharacter()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('deleteCharacter()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('removes a character in the range and preserves the range', () => {
+    it('removes a character in the this.range and preserves the this.range', function () {
       // <div>|ab|c</div>
       const host = $('<div>abc</div>')
-      range.setStart(host[0].firstChild, 0)
-      range.setEnd(host[0].firstChild, 2)
+      this.range.setStart(host[0].firstChild, 0)
+      this.range.setEnd(host[0].firstChild, 2)
 
-      range = content.deleteCharacter(host[0], range, 'a')
+      this.range = content.deleteCharacter(host[0], this.range, 'a')
       expect(host.html()).toEqual('bc')
 
       // show resulting text nodes
       expect(host[0].childNodes.length).toEqual(1)
       expect(host[0].childNodes[0].nodeValue).toEqual('bc')
 
-      // check range. It should look like this:
+      // check this.range. It should look like this:
       // <div>|b|c</div>
-      expect(range.startContainer).toEqual(host[0])
-      expect(range.startOffset).toEqual(0)
-      expect(range.endContainer).toEqual(host[0].firstChild)
-      expect(range.endOffset).toEqual(1)
-      expect(range.toString()).toEqual('b')
+      expect(this.range.startContainer).toEqual(host[0])
+      expect(this.range.startOffset).toEqual(0)
+      expect(this.range.endContainer).toEqual(host[0].firstChild)
+      expect(this.range.endOffset).toEqual(1)
+      expect(this.range.toString()).toEqual('b')
     })
 
-    it('works with a partially selected tag', () => {
+    it('works with a partially selected tag', function () {
       // <div>|a<em>b|b</em></div>
       const host = $('<div>a<em>bb</em></div>')
-      range.setStart(host[0].firstChild, 0)
-      range.setEnd(host.find('em')[0].firstChild, 1)
+      this.range.setStart(host[0].firstChild, 0)
+      this.range.setEnd(host.find('em')[0].firstChild, 1)
 
-      range = content.deleteCharacter(host[0], range, 'b')
+      this.range = content.deleteCharacter(host[0], this.range, 'b')
       expect(host.html()).toEqual('a<em>b</em>')
 
       // show resulting nodes
@@ -298,134 +289,130 @@ describe('Content', () => {
     })
   })
 
-  describe('toggleTag()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('toggleTag()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('toggles a <b> tag', () => {
+    it('toggles a <b> tag', function () {
       // <div><b>|a|</b></div>
       const host = $('<div><b>a</b></div>')
-      range.setStart(host.find('b')[0], 0)
-      range.setEnd(host.find('b')[0], 1)
+      this.range.setStart(host.find('b')[0], 0)
+      this.range.setEnd(host.find('b')[0], 1)
 
-      range = content.toggleTag(host[0], range, $('<b>')[0])
+      this.range = content.toggleTag(host[0], this.range, $('<b>')[0])
       expect(host.html()).toEqual('a')
 
-      content.toggleTag(host[0], range, $('<b>')[0])
+      content.toggleTag(host[0], this.range, $('<b>')[0])
       expect(host.html()).toEqual('<b>a</b>')
     })
   })
 
-  describe('nuke()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('nuke()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('removes surrounding <b>', () => {
+    it('removes surrounding <b>', function () {
       // <div><b>|a|</b></div>
       const host = $('<div><b>a</b></div>')
-      range.setStart(host.find('b')[0], 0)
-      range.setEnd(host.find('b')[0], 1)
-      content.nuke(host[0], range)
+      this.range.setStart(host.find('b')[0], 0)
+      this.range.setEnd(host.find('b')[0], 1)
+      content.nuke(host[0], this.range)
       expect(host.html()).toEqual('a')
     })
 
-    it('removes tons of tags', () => {
+    it('removes tons of tags', function () {
       // <div><b>|a<i>b</i><em>c|d</em></b></div>
       const host = $('<div><b>a<i>b</i><em>cd</em></b></div>')
-      range.setStart(host.find('b')[0], 0)
-      range.setEnd(host.find('em')[0].firstChild, 1)
-      content.nuke(host[0], range)
+      this.range.setStart(host.find('b')[0], 0)
+      this.range.setEnd(host.find('em')[0].firstChild, 1)
+      content.nuke(host[0], this.range)
       expect(host.html()).toEqual('abcd')
     })
 
-    it('leaves <br> alone', () => {
+    it('leaves <br> alone', function () {
       // <div>|a<br>b|</div>
       const host = $('<div>a<br>b</div>')
-      range.setStart(host[0], 0)
-      range.setEnd(host[0], 3)
-      content.nuke(host[0], range)
+      this.range.setStart(host[0], 0)
+      this.range.setEnd(host[0], 3)
+      content.nuke(host[0], this.range)
       expect(host.html()).toEqual('a<br>b')
     })
 
-    it('leaves saved range markers intact', () => {
+    it('leaves saved this.range markers intact', function () {
       // <div><b>|a|</b></div>
       const host = $('<div><b>a</b></div>')
-      range.setStart(host.find('b')[0], 0)
-      range.setEnd(host.find('b')[0], 1)
-      rangeSaveRestore.save(range)
-      content.nuke(host[0], range)
+      this.range.setStart(host.find('b')[0], 0)
+      this.range.setEnd(host.find('b')[0], 1)
+      rangeSaveRestore.save(this.range)
+      content.nuke(host[0], this.range)
       expect(host.find('span').length).toEqual(2)
       expect(host.find('b').length).toEqual(0)
     })
   })
 
-  describe('forceWrap()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('forceWrap()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('adds a link with an href attribute', () => {
+    it('adds a link with an href attribute', function () {
       // <div>|b|</div>
       const host = $('<div>b</div>')
-      range.setStart(host[0], 0)
-      range.setEnd(host[0], 1)
+      this.range.setStart(host[0], 0)
+      this.range.setEnd(host[0], 1)
 
       const $link = $('<a>')
       $link.attr('href', 'www.link.io')
 
-      content.forceWrap(host[0], range, $link[0])
+      content.forceWrap(host[0], this.range, $link[0])
       expect(host.html()).toEqual('<a href="www.link.io">b</a>')
     })
 
-    it('does not nest tags', () => {
+    it('does not nest tags', function () {
       // <div>|<em>b</em>|</div>
       const host = $('<div><em>b</em></div>')
-      range.setStart(host[0], 0)
-      range.setEnd(host[0], 1)
+      this.range.setStart(host[0], 0)
+      this.range.setEnd(host[0], 1)
 
       const $em = $('<em>')
-      content.forceWrap(host[0], range, $em[0])
+      content.forceWrap(host[0], this.range, $em[0])
       expect(host.html()).toEqual('<em>b</em>')
     })
 
-    it('removes partially selected tags', () => {
+    it('removes partially selected tags', function () {
       // <div><em>b|c|</em></div>
       const host = $('<div><em>bc</em></div>')
-      range.setStart(host.find('em')[0].firstChild, 1)
-      range.setEnd(host.find('em')[0].firstChild, 2)
+      this.range.setStart(host.find('em')[0].firstChild, 1)
+      this.range.setEnd(host.find('em')[0].firstChild, 2)
 
       const $em = $('<em>')
-      content.forceWrap(host[0], range, $em[0])
+      content.forceWrap(host[0], this.range, $em[0])
       expect(host.html()).toEqual('b<em>c</em>')
     })
   })
 
-  describe('surround()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('surround()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('wraps text in double angle quotes', () => {
+    it('wraps text in double angle quotes', function () {
       // <div><i>|b|</i></div>
       const host = $('<div><i>a</i></div>')
-      range.setStart(host.find('i')[0], 0)
-      range.setEnd(host.find('i')[0], 1)
-      content.surround(host[0], range, '«', '»')
+      this.range.setStart(host.find('i')[0], 0)
+      this.range.setEnd(host.find('i')[0], 1)
+      content.surround(host[0], this.range, '«', '»')
       expect(host.html()).toEqual('<i>«a»</i>')
     })
 
-    it('wraps text in double angle quotes', () => {
+    it('wraps text in double angle quotes', function () {
       // <div><i>|b|</i></div>
       const host = $('<div><i>a</i></div>')
-      range.setStart(host.find('i')[0], 0)
-      range.setEnd(host.find('i')[0], 1)
-      content.surround(host[0], range, '«', '»')
+      this.range.setStart(host.find('i')[0], 0)
+      this.range.setEnd(host.find('i')[0], 1)
+      content.surround(host[0], this.range, '«', '»')
 
       // the text nodes are not glued together as they should.
       // So we have 3 TextNodes after the manipulation.
@@ -433,18 +420,18 @@ describe('Content', () => {
       expect(host.find('i')[0].childNodes[1].nodeValue).toEqual('a')
       expect(host.find('i')[0].childNodes[2].nodeValue).toEqual('»')
 
-      expect(range.startContainer).toEqual(host.find('i')[0])
-      expect(range.startOffset).toEqual(0)
-      expect(range.endContainer).toEqual(host.find('i')[0])
-      expect(range.endOffset).toEqual(3)
+      expect(this.range.startContainer).toEqual(host.find('i')[0])
+      expect(this.range.startOffset).toEqual(0)
+      expect(this.range.endContainer).toEqual(host.find('i')[0])
+      expect(this.range.endOffset).toEqual(3)
     })
 
-    it('wraps text in double angle quotes', () => {
+    it('wraps text in double angle quotes', function () {
       // <div><i>a|b|</i></div>
       const host = $('<div><i>ab</i></div>')
-      range.setStart(host.find('i')[0].firstChild, 1)
-      range.setEnd(host.find('i')[0].firstChild, 2)
-      content.surround(host[0], range, '«', '»')
+      this.range.setStart(host.find('i')[0].firstChild, 1)
+      this.range.setEnd(host.find('i')[0].firstChild, 2)
+      content.surround(host[0], this.range, '«', '»')
       expect(host.html()).toEqual('<i>a«b»</i>')
 
       // the text nodes are not glued together as they should.
@@ -452,105 +439,104 @@ describe('Content', () => {
       expect(host.find('i')[0].childNodes[0].nodeValue).toEqual('a«')
       expect(host.find('i')[0].childNodes[1].nodeValue).toEqual('b')
       expect(host.find('i')[0].childNodes[2].nodeValue).toEqual('»')
-      expect(range.startContainer).toEqual(host.find('i')[0].firstChild)
-      expect(range.startOffset).toEqual(1)
-      expect(range.endContainer).toEqual(host.find('i')[0])
-      expect(range.endOffset).toEqual(3)
+      expect(this.range.startContainer).toEqual(host.find('i')[0].firstChild)
+      expect(this.range.startOffset).toEqual(1)
+      expect(this.range.endContainer).toEqual(host.find('i')[0])
+      expect(this.range.endOffset).toEqual(3)
     })
   })
 
-  describe('isExactSelection()', () => {
-    let range
-    beforeEach(() => {
-      range = rangy.createRange()
+  describe('isExactSelection()', function () {
+    beforeEach(function () {
+      this.range = rangy.createRange()
     })
 
-    it('is true if the selection is directly outside the tag', () => {
+    it('is true if the selection is directly outside the tag', function () {
       // <div>|<em>b</em>|</div>
       const host = $('<div><em>b</em></div>')
-      range.setStart(host[0], 0)
-      range.setEnd(host[0], 1)
+      this.range.setStart(host[0], 0)
+      this.range.setEnd(host[0], 1)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(true)
     })
 
-    it('is true if the selection is directly inside the tag', () => {
+    it('is true if the selection is directly inside the tag', function () {
       // <div><em>|b|</em></div>
       const host = $('<div><em>b</em></div>')
-      range.setStart(host.find('em')[0], 0)
-      range.setEnd(host.find('em')[0], 1)
+      this.range.setStart(host.find('em')[0], 0)
+      this.range.setEnd(host.find('em')[0], 1)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(true)
     })
 
-    it('is false if the selection goes beyond the tag', () => {
+    it('is false if the selection goes beyond the tag', function () {
       // <div>|a<em>b</em>|</div>
       const host = $('<div>a<em>b</em></div>')
-      range.setStart(host[0], 0)
-      range.setEnd(host[0], 2)
+      this.range.setStart(host[0], 0)
+      this.range.setEnd(host[0], 2)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(false)
     })
 
-    it('is false if the selection is only partial', () => {
+    it('is false if the selection is only partial', function () {
       // <div><em>a|b|</em></div>
       const host = $('<div><em>ab</em></div>')
-      range.setEnd(host.find('em')[0].firstChild, 1)
-      range.setEnd(host.find('em')[0].firstChild, 2)
+      this.range.setEnd(host.find('em')[0].firstChild, 1)
+      this.range.setEnd(host.find('em')[0].firstChild, 2)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(false)
     })
 
-    it('is false for a collapsed range', () => {
+    it('is false for a collapsed this.range', function () {
       // <div><em>a|b</em></div>
       const host = $('<div><em>ab</em></div>')
-      range.setEnd(host.find('em')[0].firstChild, 1)
-      range.setEnd(host.find('em')[0].firstChild, 1)
+      this.range.setEnd(host.find('em')[0].firstChild, 1)
+      this.range.setEnd(host.find('em')[0].firstChild, 1)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(false)
     })
 
-    it('is false for a collapsed range in an empty tag', () => {
+    it('is false for a collapsed this.range in an empty tag', function () {
       // <div><em>|</em></div>
       const host = $('<div><em></em></div>')
-      range.setEnd(host.find('em')[0], 0)
-      range.setEnd(host.find('em')[0], 0)
+      this.range.setEnd(host.find('em')[0], 0)
+      this.range.setEnd(host.find('em')[0], 0)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(false)
     })
 
-    it('is false if range and elem do not overlap but have the same content', () => {
+    it('is false if this.range and elem do not overlap but have the same content', function () {
       // <div>|b|<em>b</em></div>
       const host = $('<div>b<em>b</em></div>')
-      range.setEnd(host[0].firstChild, 0)
-      range.setEnd(host[0].firstChild, 1)
+      this.range.setEnd(host[0].firstChild, 0)
+      this.range.setEnd(host[0].firstChild, 1)
 
-      const exact = content.isExactSelection(range, host.find('em')[0])
+      const exact = content.isExactSelection(this.range, host.find('em')[0])
       expect(exact).toEqual(false)
     })
   })
 
-  describe('extractContent()', () => {
+  describe('extractContent()', function () {
     let $host
 
-    beforeEach(() => {
+    beforeEach(function () {
       $host = $('<div></div>')
     })
 
-    it('extracts the content', () => {
+    it('extracts the content', function () {
       $host.html('a')
       const result = content.extractContent($host[0])
       // escape to show invisible characters
       expect(escape(result)).toEqual('a')
     })
 
-    it('extracts the content from a document fragment', () => {
+    it('extracts the content from a document fragment', function () {
       $host.html('a<span>b</span>c')
       const element = $host[0]
       const fragment = document.createDocumentFragment()
@@ -560,101 +546,100 @@ describe('Content', () => {
       expect(content.extractContent(fragment)).toEqual('a<span>b</span>c')
     })
 
-    it('replaces a zeroWidthSpace with a <br> tag', () => {
+    it('replaces a zeroWidthSpace with a <br> tag', function () {
       $host.html('a\u200B')
       const result = content.extractContent($host[0])
       expect(result).toEqual('a<br>')
     })
 
-    it('removes zeroWidthNonBreakingSpaces', () => {
+    it('removes zeroWidthNonBreakingSpaces', function () {
       $host.html('a\uFEFF')
       const result = content.extractContent($host[0])
       // escape to show invisible characters
       expect(escape(result)).toEqual('a')
     })
 
-    it('removes a marked linebreak', () => {
+    it('removes a marked linebreak', function () {
       $host.html('<br data-editable="remove">')
       const result = content.extractContent($host[0])
       expect(result).toEqual('')
     })
 
-    it('removes two nested marked spans', () => {
+    it('removes two nested marked spans', function () {
       $host.html('<span data-editable="unwrap"><span data-editable="unwrap">a</span></span>')
       const result = content.extractContent($host[0])
       expect(result).toEqual('a')
     })
 
-    it('removes two adjacent marked spans', () => {
+    it('removes two adjacent marked spans', function () {
       $host.html('<span data-editable="remove"></span><span data-editable="remove"></span>')
       const result = content.extractContent($host[0])
       expect(result).toEqual('')
     })
 
-    it('unwraps two marked spans around text', () => {
+    it('unwraps two marked spans around text', function () {
       $host.html('|<span data-editable="unwrap">a</span>|<span data-editable="unwrap">b</span>|')
       const result = content.extractContent($host[0])
       expect(result).toEqual('|a|b|')
     })
 
-    it('unwraps a "ui-unwrap" span', () => {
+    it('unwraps a "ui-unwrap" span', function () {
       $host.html('a<span data-editable="ui-unwrap">b</span>c')
       const result = content.extractContent($host[0])
       expect(result).toEqual('abc')
     })
 
-    it('removes a "ui-remove" span', () => {
+    it('removes a "ui-remove" span', function () {
       $host.html('a<span data-editable="ui-remove">b</span>c')
       const result = content.extractContent($host[0])
       expect(result).toEqual('ac')
     })
 
-    describe('called with keepUiElements', () => {
-      it('does not unwrap a "ui-unwrap" span', () => {
+    describe('called with keepUiElements', function () {
+      it('does not unwrap a "ui-unwrap" span', function () {
         $host.html('a<span data-editable="ui-unwrap">b</span>c')
         const result = content.extractContent($host[0], true)
         expect(result).toEqual('a<span data-editable="ui-unwrap">b</span>c')
       })
 
-      it('does not remove a "ui-remove" span', () => {
+      it('does not remove a "ui-remove" span', function () {
         $host.html('a<span data-editable="ui-remove">b</span>c')
         const result = content.extractContent($host[0], true)
         expect(result).toEqual('a<span data-editable="ui-remove">b</span>c')
       })
     })
 
-    describe('with ranges', () => {
-      let range
-      beforeEach(() => {
+    describe('with ranges', function () {
+      beforeEach(function () {
         $host.appendTo(document.body)
-        range = rangy.createRange()
+        this.range = rangy.createRange()
       })
 
-      afterEach(() => {
+      afterEach(function () {
         $host.remove()
       })
 
-      it('removes saved ranges', () => {
+      it('removes saved ranges', function () {
         $host.html('a')
-        range.setStart($host[0], 0)
-        range.setEnd($host[0], 0)
-        rangeSaveRestore.save(range)
+        this.range.setStart($host[0], 0)
+        this.range.setEnd($host[0], 0)
+        rangeSaveRestore.save(this.range)
         const result = content.extractContent($host[0])
         expect(result).toEqual('a')
       })
 
-      it('leaves the saved ranges in the host', () => {
-        range.setStart($host[0], 0)
-        range.setEnd($host[0], 0)
-        rangeSaveRestore.save(range)
+      it('leaves the saved this.ranges in the host', function () {
+        this.range.setStart($host[0], 0)
+        this.range.setEnd($host[0], 0)
+        rangeSaveRestore.save(this.range)
         content.extractContent($host[0])
         expect($host[0].firstChild.nodeName).toEqual('SPAN')
       })
 
-      it('removes a saved range in an otherwise empty host', () => {
-        range.setStart($host[0], 0)
-        range.setEnd($host[0], 0)
-        rangeSaveRestore.save(range)
+      it('removes a saved this.range in an otherwise empty host', function () {
+        this.range.setStart($host[0], 0)
+        this.range.setEnd($host[0], 0)
+        rangeSaveRestore.save(this.range)
         const result = content.extractContent($host[0])
         expect(result).toEqual('')
       })

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -103,6 +103,27 @@ describe('Selection', function () {
       })
     })
 
+    describe('custom:', function () {
+
+      beforeEach(function () {
+        this.customElement = {tagName: 'span', attributes: {class: 'foo'}}
+      })
+
+      it('makes the selection custom tag with the configured attributes', function () {
+        this.selection.makeCustom(this.customElement)
+        const customTags = this.selection.getTagsByName(this.customElement.tagName)
+        const html = getHtml(customTags[0])
+        expect(html).toEqual('<span class="foo">foobar</span>')
+      })
+
+      it('toggles the custom selection', function () {
+        this.selection.makeCustom(this.customElement)
+        this.selection.toggleCustom(this.customElement)
+        const customTags = this.selection.getTagsByName(this.customElement.tagName)
+        expect(customTags.length).toEqual(0)
+      })
+    })
+
     describe('bold:', function () {
 
       beforeEach(function () {

--- a/src/content.js
+++ b/src/content.js
@@ -176,13 +176,13 @@ export function getTags (host, range, filterFunc) {
 
 export function getTagsByName (host, range, tagName) {
   return getTags(host, range, (node) => {
-    return node.nodeName === tagName.toUpperCase()
+    return node.nodeName.toUpperCase() === tagName.toUpperCase()
   })
 }
 
 export function getTagsByNameAndAttributes (host, range, elem) {
   return getTags(host, range, (node) => {
-    return node.nodeName === elem.nodeName.toUpperCase() &&
+    return node.nodeName.toUpperCase() === elem.nodeName.toUpperCase() &&
       areSameAttributes(node.attributes, elem.attributes)
   })
 }
@@ -190,7 +190,7 @@ export function getTagsByNameAndAttributes (host, range, elem) {
 export function areSameAttributes (attrs1, attrs2) {
   if (attrs1.length !== attrs2.length) return false
 
-  for (var i = 0; i < attrs1.length; i++) {
+  for (let i = 0; i < attrs1.length; i++) {
     const attr = attrs2[attrs1[i].name]
     if (!(attr && attr.value === attrs1[i].value)) return false
   }
@@ -319,7 +319,8 @@ export function removeFormatting (host, range, tagName) {
 // Can also affect content outside of the range.
 export function nuke (host, range, tagName) {
   getTags(host, range).forEach((elem) => {
-    if (elem.nodeName !== 'BR' && (!tagName || elem.nodeName === tagName.toUpperCase())) {
+    if (elem.nodeName.toUpperCase() !== 'BR' &&
+      (!tagName || elem.nodeName.toUpperCase() === tagName.toUpperCase())) {
       unwrap(elem)
     }
   })
@@ -329,8 +330,8 @@ export function nuke (host, range, tagName) {
 // Can also affect content outside of the range.
 export function nukeElem (host, range, node) {
   getTags(host, range).forEach((elem) => {
-    if (elem.nodeName !== 'BR' && (!node ||
-        (elem.nodeName === node.nodeName.toUpperCase() &&
+    if (elem.nodeName.toUpperCase() !== 'BR' && (!node ||
+        (elem.nodeName.toUpperCase() === node.nodeName.toUpperCase() &&
           areSameAttributes(elem.attributes, node.attributes)))) {
       unwrap(elem)
     }
@@ -388,6 +389,6 @@ export function containsString (range, str) {
 // Can also affect content outside of the range.
 export function nukeTag (host, range, tagName) {
   getTags(host, range).forEach((elem) => {
-    if (elem.nodeName === tagName) unwrap(elem)
+    if (elem.nodeName.toUpperCase() === tagName.toUpperCase()) unwrap(elem)
   })
 }

--- a/src/selection.js
+++ b/src/selection.js
@@ -119,13 +119,13 @@ export default class Selection extends Cursor {
     this.setSelection()
   }
 
-  toggleCustom ({elem, attributes}) {
-    const customElem = this.createElement(elem, attributes)
+  toggleCustom ({tagName, attributes}) {
+    const customElem = this.createElement(tagName, attributes)
     this.toggle(customElem)
   }
 
-  makeCustom ({elem, attributes}) {
-    const customElem = this.createElement(elem, attributes)
+  makeCustom ({tagName, attributes}) {
+    const customElem = this.createElement(tagName, attributes)
     this.forceWrap(customElem)
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -119,6 +119,16 @@ export default class Selection extends Cursor {
     this.setSelection()
   }
 
+  toggleCustom ({elem, attributes}) {
+    const customElem = this.createElement(elem, attributes)
+    this.toggle(customElem)
+  }
+
+  makeCustom ({elem, attributes}) {
+    const customElem = this.createElement(elem, attributes)
+    this.forceWrap(customElem)
+  }
+
   makeBold () {
     const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
     this.forceWrap(bold)


### PR DESCRIPTION
# Description
Add the possibility to toggle Custom elements and to detect the wrapping elements by tagName and Attributes. On this way a span can be used twice with other attributes.

# Changelog
- toggleTag checks on the tag and attributes
- on a selection a custom element can be toggled 