### PR TITLE
fix keyboard event chaining

### DIFF
--- a/src/eventable.js
+++ b/src/eventable.js
@@ -36,8 +36,10 @@ function getEventableModule (notifyContext) {
   let listeners = {}
 
   function addListener (event, listener) {
-    listeners[event] = listeners[event] || []
-    listeners[event].unshift(listener)
+    event.split(' ').forEach(value => {
+      listeners[value] = listeners[value] || []
+      listeners[value].unshift(listener)
+    })
   }
 
   function removeListener (event, listener) {

--- a/src/eventable.js
+++ b/src/eventable.js
@@ -35,8 +35,8 @@ export default function eventable (obj, notifyContext) {
 function getEventableModule (notifyContext) {
   let listeners = {}
 
-  function addListener (event, listener) {
-    event.split(' ').forEach(value => {
+  function addListener (events, listener) {
+    events.split(' ').forEach(value => {
       listeners[value] = listeners[value] || []
       listeners[value].unshift(listener)
     })


### PR DESCRIPTION
Chained events with spaces like [this](https://github.com/livingdocsIO/editable.js/blob/master/src/dispatcher.js#L208) one were not parsed and did not work.