### PR TITLE
Fix switch event

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -183,7 +183,7 @@ export default function (editable) {
       if (!isFromFirstExample(elem)) return
       showEvent({
         name: 'split',
-        content: 'Split this block'
+        content: <span>Split this block</span>
       })
     })
 
@@ -195,7 +195,7 @@ export default function (editable) {
 
       showEvent({
         name: 'merge',
-        content: content
+        content: <span>{content}</span>
       })
     })
 
@@ -207,7 +207,7 @@ export default function (editable) {
 
       showEvent({
         name: 'switch',
-        content: content
+        content: <span>{content}</span>
       })
     })
 

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -45,6 +45,26 @@ export default class Cursor {
     )
   }
 
+  isAtLastLine () {
+    const range = rangy.createRange()
+    range.selectNodeContents(this.host)
+
+    const hostCoords = range.nativeRange.getBoundingClientRect()
+    const cursorCoords = this.range.nativeRange.getBoundingClientRect()
+
+    return hostCoords.bottom === cursorCoords.bottom
+  }
+
+  isAtFirstLine () {
+    const range = rangy.createRange()
+    range.selectNodeContents(this.host)
+
+    const hostCoords = range.nativeRange.getBoundingClientRect()
+    const cursorCoords = this.range.nativeRange.getBoundingClientRect()
+
+    return hostCoords.top === cursorCoords.top
+  }
+
   isAtBeginning () {
     return parser.isBeginningOfHost(
       this.host,

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -173,11 +173,9 @@ export default class Dispatcher {
     setTimeout(() => {
       var newCursor = this.selectionWatcher.forceCursor()
       if (newCursor.equals(cursor)) {
-        event.preventDefault()
-        event.stopPropagation()
         this.notify('switch', element, direction, newCursor)
       }
-    }, 0)
+    })
   }
 
   /**
@@ -205,15 +203,21 @@ export default class Dispatcher {
     const self = this
 
     this.keyboard
-      .on('left up', function (event) {
+      .on('up', function (event) {
         self.dispatchSwitchEvent(event, this, 'before')
       })
 
-      .on('right down', function (event) {
+      .on('left', function (event) {
+        self.dispatchSwitchEvent(event, this, 'before')
+      })
+
+      .on('right', function (event) {
         self.dispatchSwitchEvent(event, this, 'after')
       })
 
-      .on('tab shiftTab esc', () => {})
+      .on('down', function (event) {
+        self.dispatchSwitchEvent(event, this, 'after')
+      })
 
       .on('backspace', function (event) {
         const range = self.selectionWatcher.getFreshRange()

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -168,14 +168,18 @@ export default class Dispatcher {
 
     const cursor = this.selectionWatcher.getSelection()
     if (!cursor || cursor.isSelection) return
-    // Detect if the browser moved the cursor in the next tick.
-    // If the cursor stays at its position, fire the switch event.
-    setTimeout(() => {
-      var newCursor = this.selectionWatcher.forceCursor()
-      if (newCursor.equals(cursor)) {
-        this.notify('switch', element, direction, newCursor)
-      }
-    })
+
+    if (direction === 'up' && cursor.isAtFirstLine()) {
+      event.preventDefault()
+      event.stopPropagation()
+      this.notify('switch', element, direction, cursor)
+    }
+
+    if (direction === 'down' && cursor.isAtLastLine()) {
+      event.preventDefault()
+      event.stopPropagation()
+      this.notify('switch', element, direction, cursor)
+    }
   }
 
   /**
@@ -204,19 +208,11 @@ export default class Dispatcher {
 
     this.keyboard
       .on('up', function (event) {
-        self.dispatchSwitchEvent(event, this, 'before')
-      })
-
-      .on('left', function (event) {
-        self.dispatchSwitchEvent(event, this, 'before')
-      })
-
-      .on('right', function (event) {
-        self.dispatchSwitchEvent(event, this, 'after')
+        self.dispatchSwitchEvent(event, this, 'up')
       })
 
       .on('down', function (event) {
-        self.dispatchSwitchEvent(event, this, 'after')
+        self.dispatchSwitchEvent(event, this, 'down')
       })
 
       .on('backspace', function (event) {


### PR DESCRIPTION
## Motivation

The switch event was broken due to wrong keyboard event handling.

And then there is the issue that the switch event should allow to move the cursor to the previous or next content block in the same way as the browser does when all text is in the same contenteditable.

To do this even after this PR we lack some functionality. We need to store the `x` position when a user first presses either key up or down and then send these coordinates with the switch event once the cursor reaches the boundary of the current contenteditable.

And to finish it up we would need a method to insert the cursor at the beginning or end of a contenteditable at coordinate `x`.


## Changelog

- 🐞 Trigger switch event again
- 🍬 The switch event now triggers when pressing key up in the first line of text and key down at the last line of text. It will also prevent the cursor to jump to the start or end of the line. (Currently we compare y coordinates for this detection. But I'm not 100% sure this is never thrown off by different text sizes or markup like superscript)
- 🔧 Fix React warnings in example page
