### PR TITLE
Prevent accidental deep cloning.

### DIFF
--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -78,7 +78,7 @@ export default function createDefaultBehavior (editable) {
     },
 
     split (element, before, after, cursor) {
-      const newNode = element.cloneNode()
+      const newNode = element.cloneNode(false)
       newNode.appendChild(before)
 
       const parent = element.parentNode


### PR DESCRIPTION
Addresses issue https://github.com/livingdocsIO/editable.js/issues/188. According to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode) the `cloneNode()` default paramenter `deep` changes for different DOM and browser versions, and it should _always_ be specified. All other uses of `cloneNode()` are fine.