### PR TITLE
Fix documentation typo.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -27,8 +27,8 @@ export function getHost (node) {
 }
 
 /**
- * Get the index of a node.
- * So that parent.childNodes[ getIndex(node) ] would return the node again
+ * Get the index of a node so that
+ * parent.childNodes[ getNodeIndex(node) ] would return the node again.
  *
  * @method getNodeIndex
  * @param {HTMLElement}


### PR DESCRIPTION
I think the example called to the wrong function.

Another typo, I think, is here:

https://github.com/livingdocsIO/editable.js/blob/35e4e2a767db6351810a513bdcec4c69ee583057/src/parser.js#L189-L200

The function should be called `lastChild()` and not “latest”. However, I suspect that that’s a breaking change, within this repo and I suspect to other users of this package. So, if interested I can submit a PR and use a trampoline function to maintain compatibility — if you folks care 😉