### PR TITLE
Fix paste bug in default behavior: first pasted block element was duplicated.

### DIFF
--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -149,9 +149,10 @@ export default function createDefaultBehavior (editable) {
     },
 
     paste (element, blocks, cursor) {
-      cursor.insertBefore(blocks[0])
+      if (blocks.length === 0) return
 
-      if (blocks.length <= 1) return cursor.setVisibleSelection()
+      cursor.insertBefore(blocks.shift())
+      if (blocks.length === 0) return cursor.setVisibleSelection()
 
       var parent = element.parentNode
       var currentElement = element


### PR DESCRIPTION
That’s because the first element of `blocks` was inserted at the cursor position

https://github.com/livingdocsIO/editable.js/blob/373d654c0cc214a4430bcc067a7e53b583224e41/src/create-default-behavior.js#L152

and then, if more block elements were pasted, it was iterated over _again_:

https://github.com/livingdocsIO/editable.js/blob/373d654c0cc214a4430bcc067a7e53b583224e41/src/create-default-behavior.js#L159

Fix: [shift()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift) the first `blocks` element out of the array.