### PR TITLE
Extract specific highlight ranges

### DIFF
--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -11,13 +11,14 @@ function setupHighlightEnv (context, text) {
   context.$div = $('<div>' + context.text + '</div>').appendTo(document.body)
   context.editable = new Editable()
   context.editable.add(context.$div)
-  context.highlightRange = (highlightId, start, end, dispatcher) => {
+  context.highlightRange = (highlightId, start, end, dispatcher, type) => {
     return highlightSupport.highlightRange(
       context.$div[0],
       highlightId,
       start,
       end,
-      dispatcher
+      dispatcher,
+      type
     )
   }
 
@@ -29,8 +30,8 @@ function setupHighlightEnv (context, text) {
     )
   }
 
-  context.extract = function () {
-    return context.editable.getHighlightPositions({editableHost: context.$div[0]})
+  context.extract = function (type) {
+    return context.editable.getHighlightPositions({editableHost: context.$div[0], type})
   }
 
   context.getHtml = function () {
@@ -395,6 +396,24 @@ o Round</span>`)
 
       const highlightSpan = this.$div.find('[data-word-id="myId"]')
       expect(highlightSpan.length).toEqual(0)
+    })
+
+    it('returns only highlightRanges with specific type', function () {
+      const startIndex = this.highlightRange('myId', 3, 7)
+      this.highlightRange('spellcheckId', 18, 22, undefined, 'spellcheck')
+      const expectedRanges = {
+        myId: {
+          text: 'ple ',
+          start: 3,
+          end: 7
+        }
+      }
+      const expectedHtml = this.formatHtml(`Peo
+<span class="highlight-comment" data-word-id="myId" data-editable="ui-unwrap" data-highlight="comment">ple </span>
+Make The <br> W<span class="highlight-comment" data-word-id="spellcheckId" data-editable="ui-unwrap" data-highlight="spellcheck">orld</span> Go Round`)
+      expect(this.getHtml()).toEqual(expectedHtml)
+      expect(this.extract('comment')).toEqual(expectedRanges)
+      expect(startIndex).toEqual(3)
     })
   })
 

--- a/src/core.js
+++ b/src/core.js
@@ -379,7 +379,7 @@ const Editable = module.exports = class Editable {
   }
 
   /**
-   * Extracts positions of all DOMNodes that match `[data-word-id]`.
+   * Extracts positions of all DOMNodes that match `[data-word-id]` and the `[data-highlight]`
    *
    * Returns an object where the keys represent a highlight id and the value
    * a text range object of shape:
@@ -388,12 +388,14 @@ const Editable = module.exports = class Editable {
    * ```
    *
    * @param  {Object} options
-   * @param  {DOMNode} options.editableHos
+   * @param  {DOMNode} options.editableHost
+   * @param  {String} [options.type]
    * @return {Object} ranges
    */
-  getHighlightPositions ({ editableHost }) {
+  getHighlightPositions ({ editableHost, type }) {
     return highlightSupport.extractHighlightedRanges(
-      editableHost
+      editableHost,
+      type
     )
   }
 

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -31,7 +31,7 @@ const highlightSupport = {
     }
   },
 
-  highlightRange (editableHost, highlightId, startIndex, endIndex, dispatcher) {
+  highlightRange (editableHost, highlightId, startIndex, endIndex, dispatcher, type) {
     if (this.hasHighlight(editableHost, highlightId)) {
       this.removeHighlight(editableHost, highlightId)
     }
@@ -44,7 +44,7 @@ const highlightSupport = {
 
     const marker = highlightSupport.createMarkerNode(
       '<span class="highlight-comment" data-word-id="' + highlightId + '"></span>',
-      'comment',
+      type || 'comment',
       this.win
     )
     const fragment = range.extractContents()
@@ -83,8 +83,10 @@ const highlightSupport = {
     return !!matches.length
   },
 
-  extractHighlightedRanges (editableHost) {
-    const markers = $(editableHost).find('[data-word-id]')
+  extractHighlightedRanges (editableHost, type) {
+    let findMarkersQuery = '[data-word-id]'
+    if (type) findMarkersQuery += '[data-highlight="' + type + '"]'
+    const markers = $(editableHost).find(findMarkersQuery)
     if (!markers.length) {
       return
     }


### PR DESCRIPTION
# Motivation
At the moment all highlight ranges are returned in the `getHighlightPositions()` function. Now it is possible to get only a specific type of highlights. 

Changelog
🍬add type param to `getHighlightPositions` function to get only highlightRanges from a specific type.