### PR TITLE
chore(config): Update config before tests

### DIFF
--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -35,6 +35,10 @@ describe('Editable configuration', function () {
   describe('globalConfig()', function () {
     const originalConfig = cloneDeep(config)
 
+    beforeAll(function () {
+      Editable.globalConfig(originalConfig)
+    })
+
     afterEach(function () {
       Editable.globalConfig(originalConfig)
     })


### PR DESCRIPTION
Relations:
  - Related PR's: https://github.com/livingdocsIO/editable.js/pull/208


# Motivation

A test failed on the last deployment which I've seen happen once before. I believe it could be related to the order in which tests are run, but I haven't been able to reproduce it locally (with `npm test` or using `drone`).

```
Editable configuration globalConfig() retreives the config FAILED
  Error: Expected $.linkMarkup.name = 'a' to equal 'em'.
```


# Internal Changes

Reset config before all `globalConfig()` tests are run, in addition to after each test.