### PR TITLE
feat(selection): add removeChars() method

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -41,6 +41,19 @@ describe('Selection', function () {
     })
   })
 
+  describe('removeChars()', function () {
+
+    it('removes multiple characters', function () {
+      this.div = $('<div>«Foo "bar" foo»</div>')[0]
+      const range = rangy.createRange()
+      range.selectNodeContents(this.div)
+      this.selection = new Selection(this.div, range)
+
+      this.selection.removeChars(['«', '»', '"'])
+      expect(this.div.innerHTML).toEqual('Foo bar foo')
+    })
+  })
+
   describe('textBefore() / textAfter()', function () {
 
     beforeEach(function () {

--- a/src/selection.js
+++ b/src/selection.js
@@ -182,6 +182,14 @@ export default class Selection extends Cursor {
     this.setSelection()
   }
 
+  removeChars (chars = []) {
+    for (let i = 0; i < chars.length; i++) {
+      const char = chars[i]
+      this.range = content.deleteCharacter(this.host, this.range, char)
+    }
+    this.setSelection()
+  }
+
   toggleSurround (startCharacter, endCharacter) {
     if (this.containsString(startCharacter) &&
     this.containsString(endCharacter)) {


### PR DESCRIPTION
# Changelog

* 🎁 Add method to `selection`: `selection.removeChars(['«', '»', '"'])`
