### PR TITLE
replace quotation marks

### DIFF
--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -191,9 +191,10 @@ describe('Clipboard', function () {
     })
 
     // Replace quotation marks
-    // ------------------
+    // -----------------------
 
     describe('replace quotes', function () {
+
       beforeEach(function () {
         const updatedConfig = cloneDeep(config)
         updatedConfig.pastedHtmlRules.replaceQuotes = {
@@ -205,7 +206,7 @@ describe('Clipboard', function () {
         updateConfig(updatedConfig)
       })
 
-      it('do nothting when replaceQuotes is not set', function () {
+      it('does nothing when replaceQuotes is not set', function () {
         const updatedConfig = cloneDeep(config)
         updatedConfig.pastedHtmlRules.replaceQuotes = undefined
 
@@ -214,77 +215,114 @@ describe('Clipboard', function () {
         expect(block).toEqual('text outside "text inside"')
       })
 
-      it('replace quotation marks', function () {
+      it('does nothing when apostrophe is undefined', function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = {
+          quotes: ['“', '”'],
+          singleQuotes: ['‘', '’'],
+          apostrophe: undefined
+        }
+
+        updateConfig(updatedConfig)
+        const block = extractSingleBlock(`someone: "it's the economy, stupid!"`)
+        expect(block).toEqual(`someone: “it's the economy, stupid!”`)
+      })
+
+      it('does nothing when replaceQuotes is undefined', function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = undefined
+
+        updateConfig(updatedConfig)
+        const block = extractSingleBlock(`"it's a 'wonder'"`)
+        expect(block).toEqual(`"it's a 'wonder'"`)
+      })
+
+      it('replaces quotation marks', function () {
         const block = extractSingleBlock('text outside "text inside"')
         expect(block).toEqual('text outside “text inside”')
       })
 
-      it('replace nested quotation marks', function () {
+      it('replaces empty quotation marks', function () {
+        const block = extractSingleBlock('empty "" quotes')
+        expect(block).toEqual('empty “” quotes')
+      })
+
+      it('replaces empty nested quotation marks', function () {
+        const block = extractSingleBlock(`"''"`)
+        expect(block).toEqual('“‘’”')
+      })
+
+      it('replaces nested double quotation marks', function () {
         const block = extractSingleBlock('text outside "text «inside» text"')
         expect(block).toEqual('text outside “text “inside” text”')
       })
 
-      it('replace multiple nested quotation marks', function () {
+      it('replaces multiple nested quotation marks', function () {
         const block = extractSingleBlock('text outside "text «inside „double nested“» text"')
         expect(block).toEqual('text outside “text “inside “double nested”” text”')
       })
 
-      it('replace quotation marks and ignore not closing marks', function () {
+      it('replaces quotation marks and ignore not closing marks', function () {
         const block = extractSingleBlock('text outside "text «inside „double nested» text"')
         expect(block).toEqual('text outside “text “inside „double nested” text”')
       })
 
-      it('replace nested quotes with multiple quotes inside nested', function () {
+      it('replaces nested quotes with multiple quotes inside nested', function () {
         const block = extractSingleBlock('text outside "text «inside» „second inside text“"')
         expect(block).toEqual('text outside “text “inside” “second inside text””')
       })
 
-      it('replace nested quotes with multiple quotes inside nested and not closing marks', function () {
+      it('replaces nested quotes with multiple quotes inside nested and not closing marks', function () {
         const block = extractSingleBlock('text outside "text «inside» „second «inside» text"')
         expect(block).toEqual('text outside “text “inside” „second “inside” text”')
       })
 
-      it('replace apostrophe', function () {
+      it('replaces apostrophe', function () {
         const block = extractSingleBlock(`don't`)
         expect(block).toEqual('don’t')
       })
 
-      it('replace apostrophe inside quotes', function () {
+      it('replaces apostrophe inside quotes', function () {
         const block = extractSingleBlock(`outside "don't"`)
         expect(block).toEqual('outside “don’t”')
       })
 
-      it('replace single quotation marks', function () {
-        const block = extractSingleBlock('text outside \'text inside\'')
+      it('replaces single quotation marks', function () {
+        const block = extractSingleBlock(`text outside 'text inside'`)
         expect(block).toEqual('text outside ‘text inside’')
       })
 
-      it('replace nested quotes with single quotes inside nested', function () {
-        const block = extractSingleBlock('text outside "text \'inside\' „second inside text“"')
+      it('replaces nested quotes with single quotes inside nested', function () {
+        const block = extractSingleBlock(`text outside "text 'inside' „second inside text“"`)
         expect(block).toEqual('text outside “text ‘inside’ “second inside text””')
       })
 
-      it('replace nested quotes with single quotes inside nested', function () {
+      it('does not replace two apostrophe with quotes', function () {
+        const block = extractSingleBlock(`It's a cat's world.`)
+        expect(block).toEqual(`It’s a cat’s world.`)
+      })
+
+      it('replaces nested quotes with single quotes inside nested', function () {
         const block = extractSingleBlock(`text outside "text 'inside „second inside text“'"`)
         expect(block).toEqual('text outside “text ‘inside “second inside text”’”')
       })
 
-      it('replace quotation marks around elements', function () {
+      it('replaces quotation marks around elements', function () {
         const block = extractSingleBlock('text outside "<b>text inside</b>"')
         expect(block).toEqual('text outside “<strong>text inside</strong>”')
       })
 
-      it('replace quotation marks inside elements', function () {
+      it('replaces quotation marks inside elements', function () {
         const block = extractSingleBlock('text outside <b>"text inside"</b>')
         expect(block).toEqual('text outside <strong>“text inside”</strong>')
       })
 
-      it('do not replace quotation marks inside tag attributes', function () {
+      it('does not replace quotation marks inside tag attributes', function () {
         const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
         expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
       })
 
-      it('replace quotation marks around elements with attributes', function () {
+      it('replaces quotation marks around elements with attributes', function () {
         const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
         expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
       })

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -193,6 +193,15 @@ describe('Clipboard', function () {
     // Replace quotation marks
     // ------------------
 
+    it('do nothting when replaceQuotes is not set', function () {
+      const updatedConfig = cloneDeep(config)
+      updatedConfig.pastedHtmlRules.replaceQuotes = undefined
+
+      updateConfig(updatedConfig)
+      const block = extractSingleBlock('text outside "text inside"')
+      expect(block).toEqual('text outside "text inside"')
+    })
+
     it('replace quotation marks', function () {
       const block = extractSingleBlock('text outside "text inside"')
       expect(block).toEqual('text outside “text inside”')
@@ -223,14 +232,29 @@ describe('Clipboard', function () {
       expect(block).toEqual('text outside “text “inside” „second “inside” text”')
     })
 
+    it('replace apostrophe', function () {
+      const block = extractSingleBlock(`don't`)
+      expect(block).toEqual('don’t')
+    })
+
+    it('replace apostrophe inside quotes', function () {
+      const block = extractSingleBlock(`outside "don't"`)
+      expect(block).toEqual('outside “don’t”')
+    })
+
     it('replace single quotation marks', function () {
-      const blocks = extract('text outside \'text inside\'')
-      expect(blocks).toEqual('text outside ‘text inside’')
+      const block = extractSingleBlock('text outside \'text inside\'')
+      expect(block).toEqual('text outside ‘text inside’')
     })
 
     it('replace nested quotes with single quotes inside nested', function () {
       const block = extractSingleBlock('text outside "text \'inside\' „second inside text“"')
       expect(block).toEqual('text outside “text ‘inside’ “second inside text””')
+    })
+
+    it('replace nested quotes with single quotes inside nested', function () {
+      const block = extractSingleBlock(`text outside "text 'inside „second inside text“'"`)
+      expect(block).toEqual('text outside “text ‘inside “second inside text”’”')
     })
 
     it('replace quotation marks around elements', function () {

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -193,88 +193,101 @@ describe('Clipboard', function () {
     // Replace quotation marks
     // ------------------
 
-    it('do nothting when replaceQuotes is not set', function () {
-      const updatedConfig = cloneDeep(config)
-      updatedConfig.pastedHtmlRules.replaceQuotes = undefined
+    describe('replace quotes', function () {
+      beforeEach(function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = {
+          quotes: ['“', '”'],
+          singleQuotes: ['‘', '’'],
+          apostrophe: '’'
+        }
 
-      updateConfig(updatedConfig)
-      const block = extractSingleBlock('text outside "text inside"')
-      expect(block).toEqual('text outside "text inside"')
-    })
+        updateConfig(updatedConfig)
+      })
 
-    it('replace quotation marks', function () {
-      const block = extractSingleBlock('text outside "text inside"')
-      expect(block).toEqual('text outside “text inside”')
-    })
+      it('do nothting when replaceQuotes is not set', function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = undefined
 
-    it('replace nested quotation marks', function () {
-      const block = extractSingleBlock('text outside "text «inside» text"')
-      expect(block).toEqual('text outside “text “inside” text”')
-    })
+        updateConfig(updatedConfig)
+        const block = extractSingleBlock('text outside "text inside"')
+        expect(block).toEqual('text outside "text inside"')
+      })
 
-    it('replace multiple nested quotation marks', function () {
-      const block = extractSingleBlock('text outside "text «inside „double nested“» text"')
-      expect(block).toEqual('text outside “text “inside “double nested”” text”')
-    })
+      it('replace quotation marks', function () {
+        const block = extractSingleBlock('text outside "text inside"')
+        expect(block).toEqual('text outside “text inside”')
+      })
 
-    it('replace quotation marks and ignore not closing marks', function () {
-      const block = extractSingleBlock('text outside "text «inside „double nested» text"')
-      expect(block).toEqual('text outside “text “inside „double nested” text”')
-    })
+      it('replace nested quotation marks', function () {
+        const block = extractSingleBlock('text outside "text «inside» text"')
+        expect(block).toEqual('text outside “text “inside” text”')
+      })
 
-    it('replace nested quotes with multiple quotes inside nested', function () {
-      const block = extractSingleBlock('text outside "text «inside» „second inside text“"')
-      expect(block).toEqual('text outside “text “inside” “second inside text””')
-    })
+      it('replace multiple nested quotation marks', function () {
+        const block = extractSingleBlock('text outside "text «inside „double nested“» text"')
+        expect(block).toEqual('text outside “text “inside “double nested”” text”')
+      })
 
-    it('replace nested quotes with multiple quotes inside nested and not closing marks', function () {
-      const block = extractSingleBlock('text outside "text «inside» „second «inside» text"')
-      expect(block).toEqual('text outside “text “inside” „second “inside” text”')
-    })
+      it('replace quotation marks and ignore not closing marks', function () {
+        const block = extractSingleBlock('text outside "text «inside „double nested» text"')
+        expect(block).toEqual('text outside “text “inside „double nested” text”')
+      })
 
-    it('replace apostrophe', function () {
-      const block = extractSingleBlock(`don't`)
-      expect(block).toEqual('don’t')
-    })
+      it('replace nested quotes with multiple quotes inside nested', function () {
+        const block = extractSingleBlock('text outside "text «inside» „second inside text“"')
+        expect(block).toEqual('text outside “text “inside” “second inside text””')
+      })
 
-    it('replace apostrophe inside quotes', function () {
-      const block = extractSingleBlock(`outside "don't"`)
-      expect(block).toEqual('outside “don’t”')
-    })
+      it('replace nested quotes with multiple quotes inside nested and not closing marks', function () {
+        const block = extractSingleBlock('text outside "text «inside» „second «inside» text"')
+        expect(block).toEqual('text outside “text “inside” „second “inside” text”')
+      })
 
-    it('replace single quotation marks', function () {
-      const block = extractSingleBlock('text outside \'text inside\'')
-      expect(block).toEqual('text outside ‘text inside’')
-    })
+      it('replace apostrophe', function () {
+        const block = extractSingleBlock(`don't`)
+        expect(block).toEqual('don’t')
+      })
 
-    it('replace nested quotes with single quotes inside nested', function () {
-      const block = extractSingleBlock('text outside "text \'inside\' „second inside text“"')
-      expect(block).toEqual('text outside “text ‘inside’ “second inside text””')
-    })
+      it('replace apostrophe inside quotes', function () {
+        const block = extractSingleBlock(`outside "don't"`)
+        expect(block).toEqual('outside “don’t”')
+      })
 
-    it('replace nested quotes with single quotes inside nested', function () {
-      const block = extractSingleBlock(`text outside "text 'inside „second inside text“'"`)
-      expect(block).toEqual('text outside “text ‘inside “second inside text”’”')
-    })
+      it('replace single quotation marks', function () {
+        const block = extractSingleBlock('text outside \'text inside\'')
+        expect(block).toEqual('text outside ‘text inside’')
+      })
 
-    it('replace quotation marks around elements', function () {
-      const block = extractSingleBlock('text outside "<b>text inside</b>"')
-      expect(block).toEqual('text outside “<strong>text inside</strong>”')
-    })
+      it('replace nested quotes with single quotes inside nested', function () {
+        const block = extractSingleBlock('text outside "text \'inside\' „second inside text“"')
+        expect(block).toEqual('text outside “text ‘inside’ “second inside text””')
+      })
 
-    it('replace quotation marks inside elements', function () {
-      const block = extractSingleBlock('text outside <b>"text inside"</b>')
-      expect(block).toEqual('text outside <strong>“text inside”</strong>')
-    })
+      it('replace nested quotes with single quotes inside nested', function () {
+        const block = extractSingleBlock(`text outside "text 'inside „second inside text“'"`)
+        expect(block).toEqual('text outside “text ‘inside “second inside text”’”')
+      })
 
-    it('do not replace quotation marks inside tag attributes', function () {
-      const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
-      expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
-    })
+      it('replace quotation marks around elements', function () {
+        const block = extractSingleBlock('text outside "<b>text inside</b>"')
+        expect(block).toEqual('text outside “<strong>text inside</strong>”')
+      })
 
-    it('replace quotation marks around elements with attributes', function () {
-      const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
-      expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
+      it('replace quotation marks inside elements', function () {
+        const block = extractSingleBlock('text outside <b>"text inside"</b>')
+        expect(block).toEqual('text outside <strong>“text inside”</strong>')
+      })
+
+      it('do not replace quotation marks inside tag attributes', function () {
+        const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
+        expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
+      })
+
+      it('replace quotation marks around elements with attributes', function () {
+        const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
+        expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
+      })
     })
   })
 })

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -189,5 +189,68 @@ describe('Clipboard', function () {
 
       expect(parseContent(div)[0]).toEqual('bar')
     })
+
+    // Replace quotation marks
+    // ------------------
+
+    it('replace quotation marks', function () {
+      const block = extractSingleBlock('text outside "text inside"')
+      expect(block).toEqual('text outside “text inside”')
+    })
+
+    it('replace nested quotation marks', function () {
+      const block = extractSingleBlock('text outside "text «inside» text"')
+      expect(block).toEqual('text outside “text “inside” text”')
+    })
+
+    it('replace multiple nested quotation marks', function () {
+      const block = extractSingleBlock('text outside "text «inside „double nested“» text"')
+      expect(block).toEqual('text outside “text “inside “double nested”” text”')
+    })
+
+    it('replace quotation marks and ignore not closing marks', function () {
+      const block = extractSingleBlock('text outside "text «inside „double nested» text"')
+      expect(block).toEqual('text outside “text “inside „double nested” text”')
+    })
+
+    it('replace nested quotes with multiple quotes inside nested', function () {
+      const block = extractSingleBlock('text outside "text «inside» „second inside text“"')
+      expect(block).toEqual('text outside “text “inside” “second inside text””')
+    })
+
+    it('replace nested quotes with multiple quotes inside nested and not closing marks', function () {
+      const block = extractSingleBlock('text outside "text «inside» „second «inside» text"')
+      expect(block).toEqual('text outside “text “inside” „second “inside” text”')
+    })
+
+    it('replace single quotation marks', function () {
+      const blocks = extract('text outside \'text inside\'')
+      expect(blocks).toEqual('text outside ‘text inside’')
+    })
+
+    it('replace nested quotes with single quotes inside nested', function () {
+      const block = extractSingleBlock('text outside "text \'inside\' „second inside text“"')
+      expect(block).toEqual('text outside “text ‘inside’ “second inside text””')
+    })
+
+    it('replace quotation marks around elements', function () {
+      const block = extractSingleBlock('text outside "<b>text inside</b>"')
+      expect(block).toEqual('text outside “<strong>text inside</strong>”')
+    })
+
+    it('replace quotation marks inside elements', function () {
+      const block = extractSingleBlock('text outside <b>"text inside"</b>')
+      expect(block).toEqual('text outside <strong>“text inside”</strong>')
+    })
+
+    it('do not replace quotation marks inside tag attributes', function () {
+      const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
+      expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
+    })
+
+    it('replace quotation marks around elements with attributes', function () {
+      const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
+      expect(block).toEqual('text outside “<a href="https://livingdocs.io">text inside</a>”')
+    })
   })
 })

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -215,7 +215,7 @@ describe('Clipboard', function () {
         expect(block).toEqual('text outside "text inside"')
       })
 
-      it('does nothing when apostrophe is undefined', function () {
+      it('does replace only quotes when apostrophe is undefined', function () {
         const updatedConfig = cloneDeep(config)
         updatedConfig.pastedHtmlRules.replaceQuotes = {
           quotes: ['“', '”'],
@@ -226,6 +226,19 @@ describe('Clipboard', function () {
         updateConfig(updatedConfig)
         const block = extractSingleBlock(`someone: "it's the economy, stupid!"`)
         expect(block).toEqual(`someone: “it's the economy, stupid!”`)
+      })
+
+      it('does replace only apostrophe when quotes are undefined', function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = {
+          quotes: undefined,
+          singleQuotes: undefined,
+          apostrophe: '’'
+        }
+
+        updateConfig(updatedConfig)
+        const block = extractSingleBlock(`someone: "it's the economy, stupid!"`)
+        expect(block).toEqual(`someone: "it’s the economy, stupid!"`)
       })
 
       it('does nothing when replaceQuotes is undefined', function () {

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -302,6 +302,42 @@ describe('Clipboard', function () {
         expect(block).toEqual(`It’s a cat’s world.`)
       })
 
+      it('does not replace two apostrophe with quotes inside quotes', function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = {
+          quotes: ['«', '»'],
+          singleQuotes: ['‹', '›'],
+          apostrophe: '’'
+        }
+
+        updateConfig(updatedConfig)
+        const block = extractSingleBlock(`'It's a cat's world.'`)
+        expect(block).toEqual(`‹It’s a cat’s world.›`)
+      })
+
+      it('does not replace apostrophe at the beginning or end with quotes', function () {
+        const updatedConfig = cloneDeep(config)
+        updatedConfig.pastedHtmlRules.replaceQuotes = {
+          quotes: ['«', '»'],
+          singleQuotes: ['‹', '›'],
+          apostrophe: '’'
+        }
+
+        updateConfig(updatedConfig)
+        const block = extractSingleBlock(`Can I ask you somethin'? “'Twas the night before Christmas,” he said.`)
+        expect(block).toEqual(`Can I ask you somethin’? «’Twas the night before Christmas,» he said.`)
+      })
+
+      it('does not replace apostrophe at the beginning or end with quotes', function () {
+        const block = extractSingleBlock(`Gehen S' 'nauf!`)
+        expect(block).toEqual(`Gehen S’ ’nauf!`)
+      })
+
+      it('replaces quotes with punctuation after the closing quote', function () {
+        const block = extractSingleBlock(`Beginning of the sentence "inside quote".`)
+        expect(block).toEqual(`Beginning of the sentence “inside quote”.`)
+      })
+
       it('replaces nested quotes with single quotes inside nested', function () {
         const block = extractSingleBlock(`text outside "text 'inside „second inside text“'"`)
         expect(block).toEqual('text outside “text ‘inside “second inside text”’”')

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -172,7 +172,7 @@ export function cleanWhitespace (str) {
 }
 
 export function replaceAllQuotes (str) {
-  if (replaceQuotes.quotes) {
+  if (replaceQuotes.quotes || replaceQuotes.singleQuotes || replaceQuotes.apostrophe) {
     return quotes.replaceAllQuotes(str, replaceQuotes)
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -79,7 +79,8 @@ export default {
 
     replaceQuotes: {
       quotes: ['“', '”'],
-      singleQuotes: ['‘', '’']
+      singleQuotes: ['‘', '’'],
+      apostrophe: '’'
     }
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -77,10 +77,11 @@ export default {
 
     keepInternalRelativeLinks: false,
 
+    // Replace quotes in a pasted content wiht quotes from config.
     replaceQuotes: {
-      quotes: ['“', '”'],
-      singleQuotes: ['‘', '’'],
-      apostrophe: '’'
+      // quotes: ['“', '”'],
+      // singleQuotes: ['‘', '’'],
+      // apostrophe: '’'
     }
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -75,6 +75,11 @@ export default {
     // and content (text content and child elements) will get removed.
     blacklistedElements: ['style', 'script'],
 
-    keepInternalRelativeLinks: false
+    keepInternalRelativeLinks: false,
+
+    replaceQuotes: {
+      quotes: ['“', '”'],
+      singleQuotes: ['‘', '’']
+    }
   }
 }

--- a/src/quotes.js
+++ b/src/quotes.js
@@ -25,6 +25,10 @@ const quotesRegex = /([‘’‹›‚'«»"“”„])(?![^<]*?>)/g
 // whitespace end of tag, or any dash (normal, en or em-dash)
 // or any opening double quote
 const beforeOpeningQuote = /\s|[>\-–—«»”"“„]/
+
+// whitespace begin of tag, or any dash (normal, en or em-dash)
+// or any closing quote, or any punctuation
+const afterClosingQuote = /\s|[<\-–—«»”"“‘’‹›'.;?:,]/
 let replacements
 
 export function replaceAllQuotes (str, replaceQuotesRules) {
@@ -80,11 +84,13 @@ function findClosingQuote (matches, position) {
   const possibleClosingSingleQuotes = getPossibleClosingQuotes(openingQuote, singleQuotePairs)
   const possibleClosingDoubleQuotes = getPossibleClosingQuotes(openingQuote, doubleQuotePairs)
   for (let i = position + 1; i < matches.length; i++) {
-    if (possibleClosingSingleQuotes.includes(matches[i].char)) {
-      return {position: i, type: 'single'}
-    }
-    if (possibleClosingDoubleQuotes.includes(matches[i].char)) {
-      return {position: i, type: 'double'}
+    if ((matches[i].after && afterClosingQuote.test(matches[i].after)) || !matches[i].after) {
+      if (possibleClosingSingleQuotes.includes(matches[i].char)) {
+        return {position: i, type: 'single'}
+      }
+      if (possibleClosingDoubleQuotes.includes(matches[i].char)) {
+        return {position: i, type: 'double'}
+      }
     }
   }
 }

--- a/src/quotes.js
+++ b/src/quotes.js
@@ -1,0 +1,111 @@
+const doubleQuotePairs = [
+  ['«', '»'], // ch german, french
+  ['»', '«'], // danish
+  ['"', '"'], // danish, not specified
+  ['“', '”'], // english US
+  ['”', '”'], // swedish
+  ['“', '“'], // chinese simplified
+  ['„', '“'] // german
+]
+const singleQuotePairs = [
+  ['‘', '’'], // english UK
+  ['‹', '›'], // ch german, french
+  ['‚', '‘'], // german
+  ['’', '’'], // swedish
+  ['›', '‹'], // danish
+  [`'`, `'`], // danish, not specified
+  [`‘`, `’`] // chinese simplified
+]
+
+const apostrophe = [
+  '’', // german
+  `'` // default
+]
+const quotesRegex = /([‘’‹›‚'«»"“”„])(?![^<]*?>)/g
+let replaceQuotes
+
+export function replaceAllQuotes (str, replaceQuotesRules) {
+  replaceQuotes = replaceQuotesRules
+  const quotes = getAllQuotes(str)
+  if (quotes && quotes.length > 0) {
+    const replacementQuotes = getReplacementArray(quotes, 0)
+    return replaceExistingQuotes(str, replacementQuotes)
+  }
+
+  return str
+}
+
+function getReplacementArray (quotes, position) {
+  const quotesArray = []
+  if (quotes.length === 1) {
+    const replacedQuote = replaceApostrophe(quotes[0])
+    return [replacedQuote]
+  }
+
+  while (position < quotes.length) {
+    const closingTag = findClosingQuote(quotes, position)
+    let nestedArray = []
+
+    if (closingTag !== undefined && closingTag.position !== position + 1 && closingTag.position !== -1) {
+      const nestedquotes = quotes.slice(position + 1, closingTag.position)
+      if (nestedquotes) {
+        nestedArray = getReplacementArray(nestedquotes, 0)
+      }
+    }
+
+    if (closingTag === undefined || closingTag.position === -1) {
+      const replacedQuote = replaceApostrophe(quotes[position])
+      quotesArray.push(replacedQuote)
+      position++
+    } else {
+      position = closingTag.position + 1
+      if (closingTag.type === 'double') {
+        quotesArray.push(...[replaceQuotes.quotes[0], ...nestedArray, replaceQuotes.quotes[1]])
+      }
+      if (closingTag.type === 'single') {
+        quotesArray.push(...[replaceQuotes.singleQuotes[0], ...nestedArray, replaceQuotes.singleQuotes[1]])
+      }
+    }
+  }
+
+  return quotesArray
+}
+
+function findClosingQuote (quotes, position) {
+  const openingQuote = quotes[position]
+  const possibleClosingSingleQuotes = getPossibleClosingQuotes(openingQuote, singleQuotePairs)
+  const possibleClosingDoubleQuotes = getPossibleClosingQuotes(openingQuote, doubleQuotePairs)
+  for (let i = position + 1; i < quotes.length; i++) {
+    if (possibleClosingSingleQuotes.includes(quotes[i])) {
+      return {position: i, type: 'single'}
+    }
+    if (possibleClosingDoubleQuotes.includes(quotes[i])) {
+      return {position: i, type: 'double'}
+    }
+  }
+}
+
+function getPossibleClosingQuotes (openingQuote, pairs) {
+  return pairs.filter(quotePair => quotePair[0] === openingQuote).map((quotePair) => quotePair[1])
+}
+
+function replaceApostrophe (quote) {
+  if (apostrophe.includes(quote)) {
+    return replaceQuotes.apostrophe
+  }
+
+  return quote
+}
+
+function getAllQuotes (str) {
+  return str.match(quotesRegex)
+}
+
+function replaceExistingQuotes (str, replacementQuotes) {
+  let index = 0
+  return str.replace(quotesRegex, (match) => {
+    const replacement = replacementQuotes[index]
+    index++
+    return replacement
+  })
+}


### PR DESCRIPTION
# Motivation
On paste the quotation marks in a text should be replaced with quotation marks set in the config. 

# Changelog
- 🎁 Add quotation mark replace on paste
added config in `pastedHtmlRules`
```
replaceQuotes: {
      quotes: ['“', '”'],
      singleQuotes: ['‘', '’'],
      apostrophe: '’'
    }
```