### PR TITLE
Provide cursor offset search and set methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   },
 
   "env": {
+    "es6": true,
     "browser": true,
     "node": true,
     "jasmine": true

--- a/spec/api.spec.js
+++ b/spec/api.spec.js
@@ -153,7 +153,6 @@ Cursor 2:                                   |
           element: $div[0],
           origCoordinates: {top: 0, left: 130}
         })
-        console.log('offset', offset)
         expect(wasFound).toEqual(true)
         expect(offset).toEqual(19)
       })

--- a/spec/api.spec.js
+++ b/spec/api.spec.js
@@ -126,11 +126,11 @@ describe('Editable', function () {
 
     describe('findClosestCursorOffset:', function () {
     /*
-Cursor1:                     | (left: 130)
-Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
-Comp 2:   Der Spieler blieb bei fünf Champions-League-Titeln stehen.
-Cursor 2:                    | (offset: 19 chars)
-    */
+     * Cursor1:                     | (left: 130)
+     * Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
+     * Comp 2:   Der Spieler blieb bei fünf Champions-League-Titeln stehen.
+     * Cursor 2:                    | (offset: 19 chars)
+     */
       it('finds the index in a text node', function () {
         $div.html('Der Spieler blieb bei fünf Champions-League-Titeln stehen.')
         const {wasFound, offset} = editable.findClosestCursorOffset({
@@ -142,11 +142,11 @@ Cursor 2:                    | (offset: 19 chars)
       })
 
       /*
-Cursor1:                      | (left: 130)
-Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
-Comp 2:   <p>Der <em>Spieler</em> blieb bei fünf <span>Champions-League-Titeln</span> stehen.</p>
-Cursor 2:                                   |
-    */
+       * Cursor1:                      | (left: 130)
+       * Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
+       * Comp 2:   <p>Der <em>Spieler</em> blieb bei fünf <span>Champions-League-Titeln</span> stehen.</p>
+       * Cursor 2:                                   |
+       */
       it('finds the index in a nested html tag structure', function () {
         $div.html('<p>Der <em>Spieler</em> blieb bei fünf <span>Champions-League-Titeln</span> stehen.</p>')
         const {wasFound, offset} = editable.findClosestCursorOffset({
@@ -167,18 +167,19 @@ Cursor 2:                                   |
       })
 
       /*
-Cursor1:                                                   |
-Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
-Comp 2:   Foo
-Cursor 2: not found
-    */
+       * Cursor1:                                                   |
+       * Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
+       * Comp 2:   Foo
+       * Cursor 2: not found
+       */
       it('returns not found for coordinates that are out of the text area', function () {
         $div.html('Foo')
-        const {wasFound} = editable.findClosestCursorOffset({
+        const {wasFound, offset} = editable.findClosestCursorOffset({
           element: $div[0],
           origCoordinates: {top: 0, left: 130}
         })
-        expect(wasFound).toEqual(false)
+        expect(wasFound).toEqual(true)
+        expect(offset).toEqual(3)
       })
     })
   })

--- a/spec/api.spec.js
+++ b/spec/api.spec.js
@@ -180,21 +180,6 @@ Cursor 2: not found
         })
         expect(wasFound).toEqual(false)
       })
-
-      /*
-        Note: for performance reasons this algorithm will not work on huge paragraphs.
-        In a news case such a huge paragraph is very rare though.
-      */
-      it('stops after 30 binary search iterations', function () {
-        $div.html(`
-          Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung.
-        `)
-        const {wasFound} = editable.findClosestCursorOffset({
-          element: $div[0],
-          origCoordinates: {top: 0, left: 530}
-        })
-        expect(wasFound).toEqual(false)
-      })
     })
   })
 })

--- a/spec/api.spec.js
+++ b/spec/api.spec.js
@@ -123,5 +123,79 @@ describe('Editable', function () {
         cursor.triggerChange()
       })
     })
+
+    describe('findClosestCursorOffset:', function () {
+    /*
+Cursor1:                     | (left: 130)
+Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
+Comp 2:   Der Spieler blieb bei fünf Champions-League-Titeln stehen.
+Cursor 2:                    | (offset: 19 chars)
+    */
+      it('finds the index in a text node', function () {
+        $div.html('Der Spieler blieb bei fünf Champions-League-Titeln stehen.')
+        const {wasFound, offset} = editable.findClosestCursorOffset({
+          element: $div[0],
+          origCoordinates: {top: 0, left: 130}
+        })
+        expect(wasFound).toEqual(true)
+        expect(offset).toEqual(19)
+      })
+
+      /*
+Cursor1:                      | (left: 130)
+Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
+Comp 2:   <p>Der <em>Spieler</em> blieb bei fünf <span>Champions-League-Titeln</span> stehen.</p>
+Cursor 2:                                   |
+    */
+      it('finds the index in a nested html tag structure', function () {
+        $div.html('<p>Der <em>Spieler</em> blieb bei fünf <span>Champions-League-Titeln</span> stehen.</p>')
+        const {wasFound, offset} = editable.findClosestCursorOffset({
+          element: $div[0],
+          origCoordinates: {top: 0, left: 130}
+        })
+        console.log('offset', offset)
+        expect(wasFound).toEqual(true)
+        expect(offset).toEqual(19)
+      })
+
+      it('returns not found for empty nodes', function () {
+        $div.html('')
+        const {wasFound} = editable.findClosestCursorOffset({
+          element: $div[0],
+          origCoordinates: {top: 0, left: 130}
+        })
+        expect(wasFound).toEqual(false)
+      })
+
+      /*
+Cursor1:                                                   |
+Comp 1:   Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt.
+Comp 2:   Foo
+Cursor 2: not found
+    */
+      it('returns not found for coordinates that are out of the text area', function () {
+        $div.html('Foo')
+        const {wasFound} = editable.findClosestCursorOffset({
+          element: $div[0],
+          origCoordinates: {top: 0, left: 130}
+        })
+        expect(wasFound).toEqual(false)
+      })
+
+      /*
+        Note: for performance reasons this algorithm will not work on huge paragraphs.
+        In a news case such a huge paragraph is very rare though.
+      */
+      it('stops after 30 binary search iterations', function () {
+        $div.html(`
+          Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung. Cristiano Ronaldo wurde 2018 mit grossem Tamtam nach Turin geholt. Mit ihm sollte Juventus – wie lange ersehnt – die Champions League gewinnen. Ronaldo, unter Druck geraten durch die Ermittlungen der spanischen Steuerfahnder und eine Vergewaltigungsanklage, hatte selbst Interesse an einem neuen, störungsfreien Betätigungsfeld und daran, mit einem dritten Klub die Champions-League-Trophäe zu erobern. Doch das ging nicht in Erfüllung.
+        `)
+        const {wasFound} = editable.findClosestCursorOffset({
+          element: $div[0],
+          origCoordinates: {top: 0, left: 530}
+        })
+        expect(wasFound).toEqual(false)
+      })
+    })
   })
 })

--- a/spec/node-iterator.spec.js
+++ b/spec/node-iterator.spec.js
@@ -22,7 +22,8 @@ describe('NodeIterator', function () {
     it('sets its properties', function () {
       expect(this.iterator.root).toEqual(this.element)
       expect(this.iterator.current).toEqual(this.element)
-      expect(this.iterator.next).toEqual(this.element)
+      expect(this.iterator.nextNode).toEqual(this.element)
+      expect(this.iterator.previous).toEqual(this.element)
     })
   })
 
@@ -63,7 +64,7 @@ describe('NodeIterator', function () {
 
       this.iterator.replaceCurrent(replacement)
       expect(this.iterator.current).toEqual(replacement)
-      expect(this.iterator.next).toEqual(null)
+      expect(this.iterator.nextNode).toEqual(null)
     })
 
     it('replaces the first character of longer a text node', function () {

--- a/src/core.js
+++ b/src/core.js
@@ -217,6 +217,15 @@ export default class Editable {
     return new Cursor($host[0], range)
   }
 
+  createRangyRange () {
+    return rangy.createRange()
+  }
+
+  createCursor (element, range) {
+    const $host = $(element).closest(this.editableSelector)
+    return new Cursor($host[0], range)
+  }
+
   createCursorAtBeginning (element) {
     return this.createCursor(element, 'beginning')
   }

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -6,6 +6,7 @@ import eventable from './eventable'
 import SelectionWatcher from './selection-watcher'
 import config from './config'
 import Keyboard from './keyboard'
+import {getTotalCharCount} from './util/element'
 
 // This will be set to true once we detect the input event is working.
 // Input event description on MDN:
@@ -165,17 +166,17 @@ export default class Dispatcher {
 
   dispatchSwitchEvent (event, element, direction) {
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
-
     const cursor = this.selectionWatcher.getSelection()
     if (!cursor || cursor.isSelection) return
-
-    if (direction === 'up' && cursor.isAtFirstLine()) {
+    
+    const totalCharCount = getTotalCharCount(element)
+    if (direction === 'up' && (cursor.isAtFirstLine() || totalCharCount === 0)) {
       event.preventDefault()
       event.stopPropagation()
       this.notify('switch', element, direction, cursor)
     }
 
-    if (direction === 'down' && cursor.isAtLastLine()) {
+    if (direction === 'down' && (cursor.isAtLastLine() || totalCharCount === 0)) {
       event.preventDefault()
       event.stopPropagation()
       this.notify('switch', element, direction, cursor)

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -6,7 +6,6 @@ import eventable from './eventable'
 import SelectionWatcher from './selection-watcher'
 import config from './config'
 import Keyboard from './keyboard'
-import {getTotalCharCount} from './util/element'
 
 // This will be set to true once we detect the input event is working.
 // Input event description on MDN:
@@ -166,17 +165,16 @@ export default class Dispatcher {
 
   dispatchSwitchEvent (event, element, direction) {
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
-    const cursor = this.selectionWatcher.getSelection()
+    const cursor = this.selectionWatcher.getFreshSelection()
     if (!cursor || cursor.isSelection) return
 
-    const totalCharCount = getTotalCharCount(element)
-    if (direction === 'up' && (cursor.isAtFirstLine() || totalCharCount === 0)) {
+    if (direction === 'up' && cursor.isAtFirstLine()) {
       event.preventDefault()
       event.stopPropagation()
       this.notify('switch', element, direction, cursor)
     }
 
-    if (direction === 'down' && (cursor.isAtLastLine() || totalCharCount === 0)) {
+    if (direction === 'down' && cursor.isAtLastLine()) {
       event.preventDefault()
       event.stopPropagation()
       this.notify('switch', element, direction, cursor)

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -168,7 +168,7 @@ export default class Dispatcher {
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
     const cursor = this.selectionWatcher.getSelection()
     if (!cursor || cursor.isSelection) return
-    
+
     const totalCharCount = getTotalCharCount(element)
     if (direction === 'up' && (cursor.isAtFirstLine() || totalCharCount === 0)) {
       event.preventDefault()

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -168,15 +168,27 @@ export default class Dispatcher {
     const cursor = this.selectionWatcher.getFreshSelection()
     if (!cursor || cursor.isSelection) return
 
+    // store position
+    if (!this.switchContext) {
+      this.switchContext = {
+        positionX: cursor.getBoundingClientRect().left,
+        events: ['cursor']
+      }
+    } else {
+      this.switchContext.events = ['cursor']
+    }
+
     if (direction === 'up' && cursor.isAtFirstLine()) {
       event.preventDefault()
       event.stopPropagation()
+      this.switchContext.events = ['switch', 'blur', 'focus', 'cursor']
       this.notify('switch', element, direction, cursor)
     }
 
     if (direction === 'down' && cursor.isAtLastLine()) {
       event.preventDefault()
       event.stopPropagation()
+      this.switchContext.events = ['switch', 'blur', 'focus', 'cursor']
       this.notify('switch', element, direction, cursor)
     }
   }

--- a/src/eventable.js
+++ b/src/eventable.js
@@ -84,6 +84,11 @@ function getEventableModule (notifyContext) {
         args.splice(0, 2)
       }
 
+      if (this.switchContext) {
+        const nextEvent = this.switchContext.events.shift()
+        if (event !== nextEvent) this.switchContext = undefined
+      }
+
       const eventListeners = listeners[event]
       if (!eventListeners) return
 

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -4,11 +4,9 @@ import * as content from './content'
 import highlightText from './highlight-text'
 import TextHighlighting from './plugins/highlighting/text-highlighting'
 
-function isInHost (el, host) {
-  if (!el.closest) {
-    el = el.parentNode
-  }
-  return el.closest('[data-editable]:not([data-word-id])') === host
+function isInHost (elem, host) {
+  if (!elem.closest) elem = elem.parentNode
+  return elem.closest('[data-editable]:not([data-word-id])') === host
 }
 
 const highlightSupport = {

--- a/src/node-iterator.js
+++ b/src/node-iterator.js
@@ -1,33 +1,70 @@
-import * as nodeType from './node-type'
+import {textNode} from './node-type'
 
 // A DOM node iterator.
 //
 // Has the ability to replace nodes on the fly and continue
 // the iteration.
 export default class NodeIterator {
-  constructor (root) {
-    this.current = this.next = this.root = root
+
+  constructor (root, method) {
+    this.current = this.previous = this.nextNode = this.root = root
+    this.iteratorFunc = this[method || 'getNext']
+  }
+
+  [Symbol.iterator] () {
+    return this
   }
 
   getNextTextNode () {
     let next
     while ((next = this.getNext())) {
-      if (next.nodeType === nodeType.textNode && next.data !== '') return next
+      if (next.nodeType === textNode && next.data !== '') return next
     }
   }
 
+  getPreviousTextNode () {
+    let prev
+    while ((prev = this.getPrevious())) {
+      if (prev.nodeType === textNode && prev.data !== '') return prev
+    }
+  }
+
+  next () {
+    const value = this.iteratorFunc()
+    return value ? {value} : {done: true}
+  }
+
   getNext () {
-    let n = this.current = this.next
-    let child = this.next = undefined
+    let n = this.current = this.nextNode
+    let child = this.nextNode = undefined
     if (this.current) {
       child = n.firstChild
 
       // Skip the children of elements with the attribute data-editable="remove"
       // This prevents text nodes that are not part of the content to be included.
       if (child && n.getAttribute('data-editable') !== 'remove') {
-        this.next = child
+        this.nextNode = child
       } else {
-        while ((n !== this.root) && !(this.next = n.nextSibling)) {
+        while ((n !== this.root) && !(this.nextNode = n.nextSibling)) {
+          n = n.parentNode
+        }
+      }
+    }
+    return this.current
+  }
+
+  getPrevious () {
+    let n = this.current = this.previous
+    let child = this.previous = undefined
+    if (this.current) {
+      child = n.lastChild
+
+      // Skip the children of elements with the attribute data-editable="remove"
+      // This prevents text nodes that are not part of the content to be included.
+      if (child && n.getAttribute('data-editable') !== 'remove') {
+        this.previous = child
+      } else {
+        while ((n !== this.root) && !(this.previous = n.previousSibling)) {
           n = n.parentNode
         }
       }
@@ -37,9 +74,10 @@ export default class NodeIterator {
 
   replaceCurrent (replacement) {
     this.current = replacement
-    this.next = undefined
+    this.nextNode = undefined
+    this.previous = undefined
     let n = this.current
-    while ((n !== this.root) && !(this.next = n.nextSibling)) {
+    while ((n !== this.root) && !(this.nextNode = n.nextSibling)) {
       n = n.parentNode
     }
   }

--- a/src/util/binary_search.js
+++ b/src/util/binary_search.js
@@ -1,0 +1,56 @@
+/*
+  This is a binary search algorithm implementation aimed at finding a character offset position
+  in a consecutive strings of characters over several lines.
+  Refer to this page in order to learn more about binary search: https://en.wikipedia.org/wiki/Binary_search_algorithm
+
+  The method takes a setup of methods to perform the partioning and returns an offset if one was found.
+  Due to maintain good performance in the Browser we limited the binary search partitions to 30. This should be enough for most cases
+  of paragraph content.
+
+  @param {Function} moveLeft control how a left movement in binary search works
+  @param {Function} leftCondition control when a left movement in binary search should be performed
+  @param {Function} moveRight control how a right movement in binary search works
+  @param {Function} upCondition control when the binary searc should move up one line (internally left movement)
+  @param {Function} downCondition control when the binary search should move down one line (internally right movement)
+  @param {Function} convergenceChecker returns true if the binary search converged on a value (considered a break condition)
+  @param {Function} foundChecker returns true if the target position has been found with binary search (considered a break condition)
+  @param {Funciton} createCursorAtCharacterOffset method that can apply the binary search offset to a real cursor (returns coordinates)
+  @param {Function} data data that is passed with the different methods
+
+  @return {Object} object with boolean `wasFound` indicating if the binary search found an offset and `offset` to indicate the actual character offset
+*/
+function binaryCursorSearch ({moveLeft, leftCondition, moveRight, upCondition, downCondition, convergenceChecker, foundChecker, createCursorAtCharacterOffset, data}) {
+  const history = []
+  const bluriness = 5
+  let found = false
+  for (let i = 0; i < 30; i++) {
+    history.push(data.currentOffset)
+    if (convergenceChecker(history)) break
+    const cursor = createCursorAtCharacterOffset({element: data.element, offset: data.currentOffset})
+    // up / down axis
+    if (upCondition({data, cursor})) {
+      moveLeft(data)
+      continue
+    } else if (downCondition({data, cursor})) {
+      moveRight(data)
+      continue
+    }
+
+    const coordinates = cursor.getCoordinates()
+    const distance = Math.abs(coordinates.left - data.origCoordinates.left)
+    if (foundChecker({distance, bluriness})) {
+      found = true
+      break
+    }
+    // left / right axis
+    if (leftCondition({data, coordinates})) {
+      moveLeft(data)
+    } else {
+      moveRight(data)
+    }
+  }
+
+  return {wasFound: found, offset: data.currentOffset}
+}
+
+module.exports = {binaryCursorSearch}

--- a/src/util/element.js
+++ b/src/util/element.js
@@ -2,13 +2,31 @@
 function textNodesUnder (node) {
   let all = []
   for (node = node.firstChild; node; node = node.nextSibling) {
-      if (node.nodeType === 3) {
+    if (node.nodeType === 3) {
       all.push(node)
-      } else {
+    } else {
       all = all.concat(textNodesUnder(node))
-      }
+    }
   }
   return all
+}
+
+// NOTE: if there is only one text node, then just that node and
+// the abs offset are returned
+function getTextNodeAndRelativeOffset ({textNodes, absOffset}) {
+  let cumulativeOffset = 0
+  let relativeOffset = 0
+  let targetNode
+  for (let i = 0; i < textNodes.length; i++) {
+    const node = textNodes[i]
+    if (absOffset <= cumulativeOffset + node.textContent.length) {
+      targetNode = node
+      relativeOffset = absOffset - cumulativeOffset
+      break
+    }
+    cumulativeOffset += node.textContent.length
+  }
+  return {node: targetNode, relativeOffset}
 }
 
 function getTotalCharCount (element) {
@@ -17,4 +35,4 @@ function getTotalCharCount (element) {
   return textNodes.reduce(reducer, 0)
 }
 
-module.exports = {getTotalCharCount}
+module.exports = {getTotalCharCount, textNodesUnder, getTextNodeAndRelativeOffset}

--- a/src/util/element.js
+++ b/src/util/element.js
@@ -1,0 +1,20 @@
+'use strict'
+function textNodesUnder (node) {
+  let all = []
+  for (node = node.firstChild; node; node = node.nextSibling) {
+      if (node.nodeType === 3) {
+      all.push(node)
+      } else {
+      all = all.concat(textNodesUnder(node))
+      }
+  }
+  return all
+}
+
+function getTotalCharCount (element) {
+  const textNodes = textNodesUnder(element)
+  const reducer = (acc, node) => acc + node.textContent.length
+  return textNodes.reduce(reducer, 0)
+}
+
+module.exports = {getTotalCharCount}

--- a/src/util/element.js
+++ b/src/util/element.js
@@ -1,19 +1,14 @@
 'use strict'
-function textNodesUnder (node) {
-  let all = []
-  for (node = node.firstChild; node; node = node.nextSibling) {
-    if (node.nodeType === 3) {
-      all.push(node)
-    } else {
-      all = all.concat(textNodesUnder(node))
-    }
-  }
-  return all
+import NodeIterator from '../node-iterator'
+
+export function textNodesUnder (node) {
+  const iterator = new NodeIterator(node, 'getNextTextNode')
+  return [...iterator]
 }
 
 // NOTE: if there is only one text node, then just that node and
 // the abs offset are returned
-function getTextNodeAndRelativeOffset ({textNodes, absOffset}) {
+export function getTextNodeAndRelativeOffset ({textNodes, absOffset}) {
   let cumulativeOffset = 0
   let relativeOffset = 0
   let targetNode
@@ -29,10 +24,8 @@ function getTextNodeAndRelativeOffset ({textNodes, absOffset}) {
   return {node: targetNode, relativeOffset}
 }
 
-function getTotalCharCount (element) {
+export function getTotalCharCount (element) {
   const textNodes = textNodesUnder(element)
   const reducer = (acc, node) => acc + node.textContent.length
   return textNodes.reduce(reducer, 0)
 }
-
-module.exports = {getTotalCharCount, textNodesUnder, getTextNodeAndRelativeOffset}


### PR DESCRIPTION
Related:
- https://github.com/livingdocsIO/livingdocs-framework/pull/573
- https://github.com/livingdocsIO/livingdocs-editor/pull/4496


## Motivation

In order to support maintaining the cursor position when moving up and down with the arrow keys in between editable containers (e.g. paragraphs) we implement methods to search a character offset given a coordinate set as well as a method to create a cursor at a given character offset.

```js
const {wasFound, offset, distance} = this.editable.findClosestCursorOffset({editable, element, origCoordinates})
if (wasFound) this.editable.createCursorAtCharacterOffset({element, offset})
```

## Changelog

### 🎁  `findClosestCursorOffset({element, origCoordinates, requiredOnFirstLine, requiredOnLastLine})`

Takes an element containing text nodes and a coordinate box and uses the `left` coordinate to position a character offset in `element` that most closely matches the left coordinate value. Returns an object with `wasFound` to indicate if a character offset could be found and `offset` to indicate the actual offset.
Internally, this uses a binary search to set the cursor at a position, calculating its bounding box, comparing the cursors left value to the given left value and iterating towards the result.

If the `requiredOnFirstLine` or `requiredOnLastLine` flags are given it will also use the `top` coordinate to make sure the character offset is only found on the right line. This is useful when navigating the cursor with the arrow key down from a paragraph to the next (requires the cursor to be on the first line).

### 🎁  `createCursorAtCharacterOffset ({element, offset})`

Creates a cursor in the given element at the given character offset. Returns the created cursor.
Calls `setVisibleSelection` internally.


### 🐞 Fire `switch` event more reliable

In certain situations the switch event was not fired. This depended on how the browser would set the the range of the current cursor. If the range of a cursor was in an element node and not a text node it would not fire. This affected emtpy editable elements the most but occurred also frequently in other situations.

## Internal Changes

### Binary Cursor Search

Add a helper method to perform a binary cursor search given a setup of methods. See the code file for more documentation.

### Element utils

Add the following util methods to perform operations on elements:
- `textNodesUnder`, returns all text nodes under a given DOM node
- `getTotalCharCount`, count all text node characters under a given DOM node
- `getTextNodeAndRelativeOffset`, takes an absolute character offset and a DOM node and loops through all nested text nodes to find the text node as well as the relative offset in that text node to which the absolute offset translates to