### PR TITLE
feat(selection): Add helper functions to select tags.

### DIFF
--- a/spec/cursor.spec.js
+++ b/spec/cursor.spec.js
@@ -151,5 +151,19 @@ describe('Cursor', function () {
         expect(this.cursor.afterHtml()).toEqual('')
       })
     })
+
+    describe('getInnerTags', function () {
+
+      it('gets the inner tags covered by the cursor', function () {
+        expect(this.cursor.getInnerTags()).toEqual([])
+      })
+    })
+
+    describe('getAncestorTags', function () {
+
+      it('gets all ancestor tags of the cursor', function () {
+        expect(this.cursor.getAncestorTags()).toEqual([])
+      })
+    })
   })
 })

--- a/src/content.js
+++ b/src/content.js
@@ -161,9 +161,14 @@ export function unwrapInternalNodes (sibling, keepUiElements) {
 
 // Get all tags that start or end inside the range
 export function getTags (host, range, filterFunc) {
-  const tags = getInnerTags(range, filterFunc)
+  const innerTags = getInnerTags(range, filterFunc)
+  const ancestorTags = getAncestorTags(host, range, filterFunc)
+  return innerTags.concat(ancestorTags)
+}
 
-  // get all tags that surround the range
+// Get all ancestor tags that start or end inside the range
+export function getAncestorTags (host, range, filterFunc) {
+  let tags = []
   let node = range.commonAncestorContainer
   while (node !== host) {
     if (!filterFunc || filterFunc(node)) tags.push(node)

--- a/src/content.js
+++ b/src/content.js
@@ -168,7 +168,7 @@ export function getTags (host, range, filterFunc) {
 
 // Get all ancestor tags that start or end inside the range
 export function getAncestorTags (host, range, filterFunc) {
-  let tags = []
+  const tags = []
   let node = range.commonAncestorContainer
   while (node !== host) {
     if (!filterFunc || filterFunc(node)) tags.push(node)

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -65,6 +65,16 @@ export default class Cursor {
     return content.getTagsByName(this.host, this.range, tagName)
   }
 
+  // Get all tags that are completely withing the current selection.
+  getInnerTags (filterFunc) {
+    return content.getInnerTags(this.range, filterFunc)
+  }
+
+  // Get all tags that surround the current selection.
+  getAncestorTags (filterFunc) {
+    return content.getAncestorTags(this.host, this.range, filterFunc)
+  }
+
   isAtEnd () {
     return parser.isEndOfHost(
       this.host,

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -65,7 +65,7 @@ export default class Cursor {
     return content.getTagsByName(this.host, this.range, tagName)
   }
 
-  // Get all tags that are completely withing the current selection.
+  // Get all tags that are completely within the current selection.
   getInnerTags (filterFunc) {
     return content.getInnerTags(this.range, filterFunc)
   }


### PR DESCRIPTION
Split the original `content.getTags()` function into two, to make its components available separately. Then make these two new functions available to the Cursor (and, thus, the Selection).