### PR TITLE
feat(selection): Remove nodes based on tag name and class.

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -303,19 +303,17 @@ export function removeFormattingElem (host, range, elem) {
   })
 }
 
-export function removeFormatting (host, range, tagName, selector) {
+export function removeFormatting (host, range, selector) {
   return restoreRange(host, range, () => {
-    nuke(host, range, tagName, selector)
+    nuke(host, range, selector)
   })
 }
 
 // Unwrap all tags this range is affected by.
 // Can also affect content outside of the range.
-export function nuke (host, range, tagName, selector) {
+export function nuke (host, range, selector) {
   getTags(host, range).forEach((elem) => {
-    if (elem.nodeName.toUpperCase() !== 'BR' &&
-      (!tagName || (elem.nodeName.toUpperCase() === tagName.toUpperCase() &&
-        (!selector || elem.matches(selector))))) {
+    if (elem.nodeName.toUpperCase() !== 'BR' && (!selector || elem.matches(selector))) {
       unwrap(elem)
     }
   })

--- a/src/content.js
+++ b/src/content.js
@@ -303,19 +303,19 @@ export function removeFormattingElem (host, range, elem) {
   })
 }
 
-export function removeFormatting (host, range, tagName, className) {
+export function removeFormatting (host, range, tagName, selector) {
   return restoreRange(host, range, () => {
-    nuke(host, range, tagName, className)
+    nuke(host, range, tagName, selector)
   })
 }
 
 // Unwrap all tags this range is affected by.
 // Can also affect content outside of the range.
-export function nuke (host, range, tagName, className) {
+export function nuke (host, range, tagName, selector) {
   getTags(host, range).forEach((elem) => {
     if (elem.nodeName.toUpperCase() !== 'BR' &&
       (!tagName || (elem.nodeName.toUpperCase() === tagName.toUpperCase() &&
-        (!className || elem.classList.contains(className))))) {
+        (!selector || elem.matches(selector))))) {
       unwrap(elem)
     }
   })

--- a/src/content.js
+++ b/src/content.js
@@ -303,18 +303,19 @@ export function removeFormattingElem (host, range, elem) {
   })
 }
 
-export function removeFormatting (host, range, tagName) {
+export function removeFormatting (host, range, tagName, className) {
   return restoreRange(host, range, () => {
-    nuke(host, range, tagName)
+    nuke(host, range, tagName, className)
   })
 }
 
 // Unwrap all tags this range is affected by.
 // Can also affect content outside of the range.
-export function nuke (host, range, tagName) {
+export function nuke (host, range, tagName, className) {
   getTags(host, range).forEach((elem) => {
     if (elem.nodeName.toUpperCase() !== 'BR' &&
-      (!tagName || elem.nodeName.toUpperCase() === tagName.toUpperCase())) {
+      (!tagName || (elem.nodeName.toUpperCase() === tagName.toUpperCase() &&
+        (!className || elem.classList.contains(className))))) {
       unwrap(elem)
     }
   })

--- a/src/selection.js
+++ b/src/selection.js
@@ -204,8 +204,10 @@ export default class Selection extends Cursor {
   }
 
   // @param {String} tagName. E.g. 'a' to remove all links; if undefined, remove all.
-  removeFormatting (tagName) {
-    this.range = content.removeFormatting(this.host, this.range, tagName)
+  // @param {String} className. E.g. 'foo' to remove all links 'a.foo'; if undefined,
+  //                            disregard the className.
+  removeFormatting (tagName, className) {
+    this.range = content.removeFormatting(this.host, this.range, tagName, className)
     this.setSelection()
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -203,11 +203,11 @@ export default class Selection extends Cursor {
     }
   }
 
-  // @param {String} tagName. E.g. 'a' to remove all links; if undefined, remove all.
-  // @param {String} selector. E.g. '.foo' or '[data-foo]' to remove all links 'a.foo'
-  //                           or 'a[data-foo]; if undefined, disregard the selector.
-  removeFormatting (tagName, selector) {
-    this.range = content.removeFormatting(this.host, this.range, tagName, selector)
+  // @param {String} selector. An element selector, e.g. 'a' or 'span.some-class'
+  //                           that represents elements to be removed; if undefined,
+  //                           remove all.
+  removeFormatting (selector) {
+    this.range = content.removeFormatting(this.host, this.range, selector)
     this.setSelection()
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -204,10 +204,10 @@ export default class Selection extends Cursor {
   }
 
   // @param {String} tagName. E.g. 'a' to remove all links; if undefined, remove all.
-  // @param {String} className. E.g. 'foo' to remove all links 'a.foo'; if undefined,
-  //                            disregard the className.
-  removeFormatting (tagName, className) {
-    this.range = content.removeFormatting(this.host, this.range, tagName, className)
+  // @param {String} selector. E.g. '.foo' or '[data-foo]' to remove all links 'a.foo'
+  //                           or 'a[data-foo]; if undefined, disregard the selector.
+  removeFormatting (tagName, selector) {
+    this.range = content.removeFormatting(this.host, this.range, tagName, selector)
     this.setSelection()
   }
 


### PR DESCRIPTION
Extend the [selection.removeFormatting()](https://github.com/livingdocsIO/editable.js/blob/77e45729651eda118ec232c0adf603171d7686b0/src/selection.js#L202-L206) function so that it can remove nodes based on tag name _and_ class name; handy if I’d like to remove e.g. `span.foo` only.