### PR TITLE
Fix content.isExactSelection comparison for text nodes

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -486,6 +486,26 @@ describe('Content', function () {
       expect(exact).toEqual(true)
     })
 
+    it('is true if the selection is a text node', function () {
+      // <div>|b|<em>b</em></div>
+      const host = createElement('<div>b<em>b</em></div>')
+      this.range.setStart(host.firstChild, 0)
+      this.range.setEnd(host.firstChild, 1)
+
+      const exact = content.isExactSelection(this.range, host.firstChild)
+      expect(exact).toEqual(true)
+    })
+
+    it('is true if the selection contains an invisible node', function () {
+      // <div>|b<script>console.log("foo")</script>|</div>
+      const host = createElement('<div>hello<script>console.log("foo")</script> world</div>')
+      this.range.setStart(host, 0)
+      this.range.setEnd(host, 3)
+
+      const exact = content.isExactSelection(this.range, host)
+      expect(exact).toEqual(true)
+    })
+
     it('is false if the selection goes beyond the tag', function () {
       // <div>|a<em>b</em>|</div>
       const host = createElement('<div>a<em>b</em></div>')
@@ -499,7 +519,7 @@ describe('Content', function () {
     it('is false if the selection is only partial', function () {
       // <div><em>a|b|</em></div>
       const host = createElement('<div><em>ab</em></div>')
-      this.range.setEnd(host.querySelector('em').firstChild, 1)
+      this.range.setStart(host.querySelector('em').firstChild, 1)
       this.range.setEnd(host.querySelector('em').firstChild, 2)
 
       const exact = content.isExactSelection(this.range, host.querySelector('em'))
@@ -509,7 +529,7 @@ describe('Content', function () {
     it('is false for a collapsed this.range', function () {
       // <div><em>a|b</em></div>
       const host = createElement('<div><em>ab</em></div>')
-      this.range.setEnd(host.querySelector('em').firstChild, 1)
+      this.range.setStart(host.querySelector('em').firstChild, 1)
       this.range.setEnd(host.querySelector('em').firstChild, 1)
 
       const exact = content.isExactSelection(this.range, host.querySelector('em'))
@@ -519,17 +539,17 @@ describe('Content', function () {
     it('is false for a collapsed this.range in an empty tag', function () {
       // <div><em>|</em></div>
       const host = createElement('<div><em></em></div>')
-      this.range.setEnd(host.querySelector('em'), 0)
+      this.range.setStart(host.querySelector('em'), 0)
       this.range.setEnd(host.querySelector('em'), 0)
 
       const exact = content.isExactSelection(this.range, host.querySelector('em'))
       expect(exact).toEqual(false)
     })
 
-    it('is false if this.range and elem do not overlap but have the same content', function () {
+    it('is false if selection and elem do not overlap but have the same content', function () {
       // <div>|b|<em>b</em></div>
       const host = createElement('<div>b<em>b</em></div>')
-      this.range.setEnd(host.firstChild, 0)
+      this.range.setStart(host.firstChild, 0)
       this.range.setEnd(host.firstChild, 1)
 
       const exact = content.isExactSelection(this.range, host.querySelector('em'))

--- a/src/content.js
+++ b/src/content.js
@@ -234,7 +234,7 @@ export function isExactSelection (range, elem, visible) {
   if (!range.intersectsRange(elemRange)) return false
 
   let rangeText = range.toString()
-  let elemText = (elem.jquery ? elem[0] : elem).innerText
+  let elemText = (elem.jquery ? elem[0] : elem).textContent
 
   if (visible) {
     rangeText = string.trim(rangeText)


### PR DESCRIPTION
Here's one first fix for something that broke when I've removed jQuery.

### Changelog
- 🐛 Fix content.isExactSelection comparison for text nodes