### PR TITLE
Introduce boundary selection event

### DIFF
--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -314,7 +314,7 @@ describe('Dispatcher', function () {
         // trigger selectionchange event
         const selectionEvent = new Event('selectionchange', {bubbles: true})
         elem.dispatchEvent(selectionEvent)
-        expect(position).toEqual('both')
+        expect(position).to.equal('both')
       })
 
       it('fires "start" if selection is at beginning but not end', function () {
@@ -332,7 +332,7 @@ describe('Dispatcher', function () {
         // trigger selectionchange event
         const selectionEvent = new Event('selectionchange', {bubbles: true})
         elem.dispatchEvent(selectionEvent)
-        expect(position).toEqual('start')
+        expect(position).to.equal('start')
       })
 
       it('fires "end" if selection is at end but not beginning', function () {
@@ -350,7 +350,7 @@ describe('Dispatcher', function () {
         // trigger selectionchange event
         const selectionEvent = new Event('selectionchange', {bubbles: true})
         elem.dispatchEvent(selectionEvent)
-        expect(position).toEqual('end')
+        expect(position).to.equal('end')
       })
     })
   })

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -141,18 +141,19 @@ describe('Dispatcher', function () {
         expect(insert.calls).to.equal(1)
       })
 
-      it('fires merge if cursor is in the middle', function () {
-        // <div>fo|o</div>
-        elem.innerHTML = 'foo'
+      it('fires "split" if cursor is in the middle', function () {
+        // <div>ba|r</div>
+        elem.innerHTML = 'bar'
         const range = rangy.createRange()
         range.setStart(elem.firstChild, 2)
         range.setEnd(elem.firstChild, 2)
+        range.collapse()
         createCursor(range)
 
         const insert = on('split', (element, before, after, cursor) => {
           expect(element).to.equal(elem)
-          expect(content.getInnerHtmlOfFragment(before)).to.equal('fo')
-          expect(content.getInnerHtmlOfFragment(after)).to.equal('o')
+          expect(content.getInnerHtmlOfFragment(before)).to.equal('ba')
+          expect(content.getInnerHtmlOfFragment(after)).to.equal('r')
           expect(cursor.isCursor).to.equal(true)
         })
 
@@ -294,6 +295,62 @@ describe('Dispatcher', function () {
 
         const evt = new KeyboardEvent('keydown', {ctrlKey: true, keyCode: key.i})
         elem.dispatchEvent(evt)
+      })
+    })
+
+    describe('selectToBoundary event:', function () {
+
+      it('fires "both" if all is selected', function () {
+        elem.innerHTML = 'People Make The World Go Round'
+        // select all
+        const range = rangy.createRange()
+        range.selectNodeContents(elem)
+        createCursor(range)
+        // listen for event
+        let position
+        editable.selectToBoundary(function (element, evt, pos) {
+          position = pos
+        })
+        // trigger selectionchange event
+        const selectionEvent = new Event('selectionchange', {bubbles: true})
+        elem.dispatchEvent(selectionEvent)
+        expect(position).toEqual('both')
+      })
+
+      it('fires "start" if selection is at beginning but not end', function () {
+        elem.innerHTML = 'People Make The World Go Round'
+        // select "People"
+        const range = rangy.createRange()
+        range.setStart(elem.firstChild, 0)
+        range.setEnd(elem.firstChild, 5)
+        createCursor(range)
+        // listen for event
+        let position
+        editable.selectToBoundary(function (element, evt, pos) {
+          position = pos
+        })
+        // trigger selectionchange event
+        const selectionEvent = new Event('selectionchange', {bubbles: true})
+        elem.dispatchEvent(selectionEvent)
+        expect(position).toEqual('start')
+      })
+
+      it('fires "end" if selection is at end but not beginning', function () {
+        elem.innerHTML = 'People Make The World Go Round'
+        // select "Round"
+        const range = rangy.createRange()
+        range.setStart(elem.firstChild, 25)
+        range.setEnd(elem.firstChild, 30)
+        createCursor(range)
+        // listen for event
+        let position
+        editable.selectToBoundary(function (element, evt, pos) {
+          position = pos
+        })
+        // trigger selectionchange event
+        const selectionEvent = new Event('selectionchange', {bubbles: true})
+        elem.dispatchEvent(selectionEvent)
+        expect(position).toEqual('end')
       })
     })
   })

--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -426,10 +426,10 @@ Make The <br> W<span class="highlight-spellcheck" data-word-id="spellcheckId" da
     })
 
     it('normalizes a simple text node after removing a highlight', function () {
-      setupHighlightEnv(self, 'People Make The World Go Round')
-      self.highlightRange('myId', 3, 7)
-      const normalizeSpy = sinon.spy(self.div, 'normalize')
-      self.removeHighlight('myId')
+      setupHighlightEnv(this, 'People Make The World Go Round')
+      this.highlightRange('myId', 3, 7)
+      const normalizeSpy = sinon.spy(this.div, 'normalize')
+      this.removeHighlight('myId')
       // There is no way to see the actual error in a test since it only happens in (non-headless)
       // Chome environments. We just check if the normalize method has been called here.
       expect(normalizeSpy.callCount).toEqual(1)

--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import sinon from 'sinon'
 import rangy from 'rangy'
 import {Editable} from '../src/core'
 import Highlighting from '../src/highlighting'
@@ -422,6 +423,17 @@ Make The <br> W<span class="highlight-spellcheck" data-word-id="spellcheckId" da
       expect(this.getHtml()).to.equal(expectedHtml)
       expect(this.extract('comment')).to.deep.equal(expectedRanges)
       expect(startIndex).to.equal(3)
+    })
+
+    it('normalizes a simple text node after removing a highlight', function () {
+      setupHighlightEnv(self, 'People Make The World Go Round')
+      self.highlightRange('myId', 3, 7)
+      const normalizeSpy = sinon.spy(self.div, 'normalize')
+      self.removeHighlight('myId')
+      // There is no way to see the actual error in a test since it only happens in (non-headless)
+      // Chome environments. We just check if the normalize method has been called here.
+      expect(normalizeSpy.callCount).toEqual(1)
+      normalizeSpy.restore()
     })
   })
 

--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -432,7 +432,7 @@ Make The <br> W<span class="highlight-spellcheck" data-word-id="spellcheckId" da
       this.removeHighlight('myId')
       // There is no way to see the actual error in a test since it only happens in (non-headless)
       // Chome environments. We just check if the normalize method has been called here.
-      expect(normalizeSpy.callCount).toEqual(1)
+      expect(normalizeSpy.callCount).to.equal(1)
       normalizeSpy.restore()
     })
   })

--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -418,7 +418,7 @@ o Round</span>`)
       }
       const expectedHtml = this.formatHtml(`Peo
 <span class="highlight-comment" data-word-id="myId" data-editable="ui-unwrap" data-highlight="comment">ple </span>
-Make The <br> W<span class="highlight-comment" data-word-id="spellcheckId" data-editable="ui-unwrap" data-highlight="spellcheck">orld</span> Go Round`)
+Make The <br> W<span class="highlight-spellcheck" data-word-id="spellcheckId" data-editable="ui-unwrap" data-highlight="spellcheck">orld</span> Go Round`)
       expect(this.getHtml()).to.equal(expectedHtml)
       expect(this.extract('comment')).to.deep.equal(expectedRanges)
       expect(startIndex).to.equal(3)

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -101,7 +101,7 @@ describe('Selection', function () {
         expect(this.selection.isAllSelected()).to.equal(true)
       })
 
-      it('returns true if all is selected', function () {
+      it('returns false if not all is selected', function () {
         const textNode = this.oneWord.firstChild
         let range = rangy.createRange()
         range.setStartBefore(textNode)

--- a/src/core.js
+++ b/src/core.js
@@ -384,9 +384,9 @@ export class Editable {
    * @param  {Boolean} options.raiseEvents do throw change events
    * @return {Number} The text-based start offset of the newly applied highlight or `-1` if the range was considered invalid.
    */
-  highlight ({editableHost, text, highlightId, textRange, raiseEvents}) {
+  highlight ({editableHost, text, highlightId, textRange, raiseEvents, type = 'comment'}) {
     if (!textRange) {
-      return highlightSupport.highlightText(editableHost, text, highlightId)
+      return highlightSupport.highlightText(editableHost, text, highlightId, type)
     }
     if (typeof textRange.start !== 'number' || typeof textRange.end !== 'number') {
       error(
@@ -400,7 +400,7 @@ export class Editable {
       )
       return -1
     }
-    return highlightSupport.highlightRange(editableHost, highlightId, textRange.start, textRange.end, raiseEvents ? this.dispatcher : undefined)
+    return highlightSupport.highlightRange(editableHost, highlightId, textRange.start, textRange.end, raiseEvents ? this.dispatcher : undefined, type)
   }
 
   /**

--- a/src/core.js
+++ b/src/core.js
@@ -521,7 +521,7 @@ Editable.browser = browser
 // Set up callback functions for several events.
 ;['focus', 'blur', 'flow', 'selection', 'cursor', 'newline',
   'insert', 'split', 'merge', 'empty', 'change', 'switch',
-  'move', 'clipboard', 'paste', 'spellcheckUpdated'
+  'move', 'clipboard', 'paste', 'spellcheckUpdated', 'selectToBoundary'
 ].forEach((name) => {
   // Generate a callback function to subscribe to an event.
   Editable.prototype[name] = function (handler) {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -276,10 +276,13 @@ export default class Dispatcher {
         const cursor = range.forceCursor()
 
         if (cursor.isAtTextEnd()) {
+          console.log('at end', event.target)
           self.notify('insert', this, 'after', cursor)
         } else if (cursor.isAtBeginning()) {
+          console.log('at beginning', event.target)
           self.notify('insert', this, 'before', cursor)
         } else {
+          console.log('in split', event.target)
           self.notify('split', this, cursor.before(), cursor.after(), cursor)
         }
       })
@@ -330,11 +333,11 @@ export default class Dispatcher {
       const cursor = this.selectionWatcher.getFreshSelection()
 
       if (cursor && cursor.isSelection && cursor.isAtBeginning() && cursor.isAtEnd()) {
-        this.notify('selectToBoundary', cursor.host, evt, 'both', cursor)
+        this.notify('selectToBoundary', cursor.host, evt, 'both')
       } else if (cursor && cursor.isSelection && cursor.isAtBeginning()) {
-        this.notify('selectToBoundary', cursor.host, evt, 'start', cursor)
+        this.notify('selectToBoundary', cursor.host, evt, 'start')
       } else if (cursor && cursor.isSelection && cursor.isAtEnd()) {
-        this.notify('selectToBoundary', cursor.host, evt, 'end', cursor)
+        this.notify('selectToBoundary', cursor.host, evt, 'end')
       }
 
       if (suppressSelectionChanges) {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -111,7 +111,7 @@ export default class Dispatcher {
         const block = this.getEditableBlockByEvent(evt)
         if (!block) return
         const selection = this.selectionWatcher.getFreshSelection()
-        if (selection.isSelection) {
+        if (selection && selection.isSelection) {
           this.notify('clipboard', block, 'copy', selection)
         }
       })
@@ -119,7 +119,7 @@ export default class Dispatcher {
         const block = this.getEditableBlockByEvent(evt)
         if (!block) return
         const selection = this.selectionWatcher.getFreshSelection()
-        if (selection.isSelection) {
+        if (selection && selection.isSelection) {
           this.notify('clipboard', block, 'cut', selection)
           this.triggerChangeEvent(block)
         }

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -276,13 +276,10 @@ export default class Dispatcher {
         const cursor = range.forceCursor()
 
         if (cursor.isAtTextEnd()) {
-          console.log('at end', event.target)
           self.notify('insert', this, 'after', cursor)
         } else if (cursor.isAtBeginning()) {
-          console.log('at beginning', event.target)
           self.notify('insert', this, 'before', cursor)
         } else {
-          console.log('in split', event.target)
           self.notify('split', this, cursor.before(), cursor.after(), cursor)
         }
       })

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -329,11 +329,11 @@ export default class Dispatcher {
     this.setupDocumentListener('selectionchange', (evt) => {
       const cursor = this.selectionWatcher.getFreshSelection()
 
-      if (cursor.isSelection && cursor.isAtBeginning() && cursor.isAtEnd()) {
+      if (cursor && cursor.isSelection && cursor.isAtBeginning() && cursor.isAtEnd()) {
         this.notify('selectToBoundary', cursor.host, evt, 'both', cursor)
-      } else if (cursor.isSelection && cursor.isAtBeginning()) {
+      } else if (cursor && cursor.isSelection && cursor.isAtBeginning()) {
         this.notify('selectToBoundary', cursor.host, evt, 'start', cursor)
-      } else if (cursor.isSelection && cursor.isAtEnd()) {
+      } else if (cursor && cursor.isSelection && cursor.isAtEnd()) {
         this.notify('selectToBoundary', cursor.host, evt, 'end', cursor)
       }
 

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -326,7 +326,17 @@ export default class Dispatcher {
 
     // fires on mousemove (thats probably a bit too much)
     // catches changes like 'select all' from context menu
-    this.setupDocumentListener('selectionchange', function (evt) {
+    this.setupDocumentListener('selectionchange', (evt) => {
+      const cursor = this.selectionWatcher.getFreshSelection()
+
+      if (cursor.isSelection && cursor.isAtBeginning() && cursor.isAtEnd()) {
+        this.notify('selectToBoundary', cursor.host, evt, 'both', cursor)
+      } else if (cursor.isSelection && cursor.isAtBeginning()) {
+        this.notify('selectToBoundary', cursor.host, evt, 'start', cursor)
+      } else if (cursor.isSelection && cursor.isAtEnd()) {
+        this.notify('selectToBoundary', cursor.host, evt, 'end', cursor)
+      }
+
       if (suppressSelectionChanges) {
         selectionDirty = true
       } else {

--- a/src/feature-detection.js
+++ b/src/feature-detection.js
@@ -16,13 +16,11 @@ const browserEngine = parser.getEngineName()
 const webKit = browserEngine === 'WebKit'
 
 /**
- * Check selectionchange event (currently supported in IE, Chrome and Safari)
- *
- * To handle selectionchange in firefox see CKEditor selection object
- * https://github.com/ckeditor/ckeditor-dev/blob/master/core/selection.js#L388
+ * Check selectionchange event (currently supported in IE, Chrome, Firefox and Safari)
+ * Firefox supports it since version 52 (2017) so pretty sure this is fine.
  */
 // not exactly feature detection... is it?
-export const selectionchange = !(browserEngine === 'Gecko' || browserName === 'Opera')
+export const selectionchange = !(browserName === 'Opera')
 
 // See Keyboard.prototype.preventContenteditableBug for more information.
 export const contenteditableSpanBug = !!webKit

--- a/src/feature-detection.js
+++ b/src/feature-detection.js
@@ -11,16 +11,30 @@ import browser from 'bowser'
 export const contenteditable = typeof document.documentElement.contentEditable !== 'undefined'
 
 const parser = browser.getParser(window.navigator.userAgent)
-const browserName = parser.getBrowser()
 const browserEngine = parser.getEngineName()
 const webKit = browserEngine === 'WebKit'
 
 /**
- * Check selectionchange event (currently supported in IE, Chrome, Firefox and Safari)
- * Firefox supports it since version 52 (2017) so pretty sure this is fine.
+ * Check selectionchange event (supported in IE, Chrome, Firefox and Safari)
+ * Firefox supports it since version 52 (2017).
+ * Opera has no support as of 2021.
  */
-// not exactly feature detection... is it?
-export const selectionchange = !(browserName === 'Opera')
+const hasNativeSelectionchangeSupport = (document) => {
+  const doc = document
+  const osc = doc.onselectionchange
+  if (osc !== undefined) {
+    try {
+      doc.onselectionchange = 0
+      return doc.onselectionchange === null
+    } catch (e) {
+    } finally {
+      doc.onselectionchange = osc
+    }
+  }
+  return false
+}
+
+export const selectionchange = hasNativeSelectionchangeSupport(document)
 
 // See Keyboard.prototype.preventContenteditableBug for more information.
 export const contenteditableSpanBug = !!webKit

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -69,6 +69,7 @@ const highlightSupport = {
     const elems = editableHost.querySelectorAll(`[data-word-id="${highlightId}"]`)
     for (const elem of elems) {
       content.unwrap(elem)
+      // in Chrome browsers the unwrap method leaves the host node split into 2 (lastChild !== firstChild)
       editableHost.normalize()
       if (dispatcher) dispatcher.notify('change', editableHost)
     }

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -28,7 +28,7 @@ const highlightSupport = {
     }
   },
 
-  highlightRange (editableHost, highlightId, startIndex, endIndex, dispatcher, type) {
+  highlightRange (editableHost, highlightId, startIndex, endIndex, dispatcher, type = 'comment') {
     if (this.hasHighlight(editableHost, highlightId)) {
       this.removeHighlight(editableHost, highlightId)
     }

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -69,6 +69,7 @@ const highlightSupport = {
     const elems = editableHost.querySelectorAll(`[data-word-id="${highlightId}"]`)
     for (const elem of elems) {
       content.unwrap(elem)
+      editableHost.normalize()
       if (dispatcher) dispatcher.notify('change', editableHost)
     }
   },

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -10,13 +10,13 @@ function isInHost (elem, host) {
 
 const highlightSupport = {
 
-  highlightText (editableHost, text, highlightId) {
+  highlightText (editableHost, text, highlightId, type) {
     if (this.hasHighlight(editableHost, highlightId)) return
 
     const blockText = highlightText.extractText(editableHost)
 
-    const marker = '<span class="highlight-comment"></span>'
-    const markerNode = highlightSupport.createMarkerNode(marker, 'highlight', this.win)
+    const marker = `<span class="highlight-${type}"></span>`
+    const markerNode = highlightSupport.createMarkerNode(marker, type, this.win)
 
     const textSearch = new TextHighlighting(markerNode, 'text')
     const matches = textSearch.findMatches(blockText, [text])
@@ -40,8 +40,8 @@ const highlightSupport = {
     }
 
     const marker = highlightSupport.createMarkerNode(
-      `<span class="highlight-comment" data-word-id="${highlightId}"></span>`,
-      type || 'comment',
+      `<span class="highlight-${type}" data-word-id="${highlightId}"></span>`,
+      type,
       this.win
     )
     const fragment = range.extractContents()


### PR DESCRIPTION
## Motivation

In order to support selections over multiple editable directives (e.g. over multiple paragraphs) we introduce the new event type `selectToBoundary` that is fired when:
- a selection is at the start of an editable directive (going up)
- a selection is at the end of an editable directive (going down)
- or a selection is at both ends (start and end)

Related Framework PR: https://github.com/livingdocsIO/livingdocs-framework/pull/582

## Changelog

### 🎁 Introduce `selectToBoundary` event

The `selectToBoundary` event fires when a text selection is dragged to a boundary of an editable: either at the start, at the end or at both ends (if e.g. all text of a paragraph is selected).
The event passes the following params: `(element, event, position)`
- element is the DOM node on which the event is called
- event is the native selection event
- position is either `start`, `end` or `both` depending on which boundary the event fires

### 🍬  support selectionchange for Firefox

Firefox (Gecko) supports the selectionchange event since 2017. Time to enable it in editable.js for this browser :)

### 🍬  allow to pass highlight type to highlight

Previously the highlight code always set the type to `comment` thus also resulting in a CSS class `highlight-comment`. We now allow to pass the type which is useful if you want to define other kinds of highlights (and according CSS classes, e.g. `selection` -> `highlight-selection`).
```
const type = 'custom'
this.editable.highlight({editableHost, text, highlightId, textRange, raiseEvents, type})
// -> will result in a highlight with css class `highlight-custom`
```

### 🐞  normalize DOM node after removing highlight

After removing a highlight (span tag) we need to normalize the parent DOM node otherwise the DOM node will still be split into 2 children (at least in Chrome).
