### PR TITLE
Use null escape instead of br tags for empty elements

### DIFF
--- a/examples/index.css
+++ b/examples/index.css
@@ -48,6 +48,13 @@ body {
 }
 
 /*
+* Chrome has issues displaying the cursor because the outline is too thick
+*/
+[contenteditable]:focus {
+    outline-offset: 1px;
+}
+
+/*
  * A better looking default horizontal rule
  */
 

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -71,7 +71,39 @@ describe('Dispatcher', function () {
       editable.unload()
     })
 
-    describe('on Enter', function () {
+    describe('on focus', function () {
+      it('should trigger the focus event', function () {
+        elem.blur()
+        const focus = on('focus', function (element) {
+          expect(element).toEqual(elem)
+        })
+        elem.focus()
+        expect(focus.calls).toBe(1)
+      })
+
+      it('should contain an empty textnode', function () {
+        elem.blur()
+        expect(elem.textContent).toEqual('')
+        elem.focus()
+        expect(elem.textContent).toEqual('\u0000')
+      })
+
+      it('should not add an empty text node if there is content', function () {
+        elem.blur()
+        elem.appendChild(document.createTextNode('Hello'))
+        elem.focus()
+        expect(elem.textContent).toEqual('Hello')
+      })
+
+      it('removes the empty text node again on blur', function () {
+        elem.focus()
+        expect(elem.textContent).toEqual('\u0000')
+        elem.blur()
+        expect(elem.textContent).toEqual('')
+      })
+    })
+
+    describe('on enter', function () {
 
       beforeEach(function () {
         event = new Event('keydown')

--- a/src/content.js
+++ b/src/content.js
@@ -14,6 +14,7 @@ function restoreRange (host, range, func) {
 const zeroWidthSpace = /\u200B/g
 const zeroWidthNonBreakingSpace = /\uFEFF/g
 const whitespaceExceptSpace = /[^\S ]/g
+const nullEscapeCharacter = /\u0000/g // eslint-disable-line no-control-regex
 
 // Clean up the Html.
 export function tidyHtml (element) {
@@ -83,6 +84,7 @@ export function extractContent (element, keepUiElements) {
     ? getInnerHtmlOfFragment(element)
     : element.innerHTML
   )
+    .replace(nullEscapeCharacter, '') // Used to generate empty text nodes on focus event.
     .replace(zeroWidthNonBreakingSpace, '') // Used for forcing inline elements to have a height
     .replace(zeroWidthSpace, '<br>') // Used for cross-browser newlines
 

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -24,13 +24,11 @@ export default function createDefaultBehavior (editable) {
 
   return {
     focus (element) {
-      // Add a <br> element if the editable is empty to force it to have height
-      // E.g. Firefox does not render empty block elements and most browsers do
-      // not render  empty inline elements.
+      // Add an empty text node if the editable is empty to force it to have height
+      // E.g. Firefox does not render empty block elements
+      //   and most browsers do not render empty inline elements.
       if (!parser.isVoid(element)) return
-      const br = document.createElement('br')
-      br.setAttribute('data-editable', 'remove')
-      element.appendChild(br)
+      element.appendChild(document.createTextNode('\u0000'))
     },
 
     blur (element) {


### PR DESCRIPTION
Before:
| Without Focus | With Focus  |
|-----------------|:-----------:|
| ![image](https://user-images.githubusercontent.com/431376/127650121-0318405f-a004-4bd0-b351-8674f7ee627a.png)      | ![image](https://user-images.githubusercontent.com/431376/127650156-2ffdbd97-7dc8-4cff-a6f2-413e85fc2960.png)    |

After:
| Without Focus | With Focus  |
|-----------------|:-----------:|
| ![image](https://user-images.githubusercontent.com/431376/127650471-7aaf3751-319f-4dcf-9208-cc0c93d51b01.png)  | ![image](https://user-images.githubusercontent.com/431376/127650489-b3ccf81c-940c-46a8-9791-3f5687555194.png) |


The cursor also shows up correctly in Chrome & Safari & Firefox.