### PR TITLE
Remove commonjs-based 'lib' output

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 import Prism from 'prismjs'
 
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 import eventList from './events.js'
 
 // Paragraph Example

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "editable"
   ],
   "license": "MIT",
-  "main": "lib/core.js",
+  "module": "src/core.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/livingdocsIO/editable.js.git"
@@ -67,8 +67,7 @@
     "start": "WEBPACK_DEV=true BUILD_DOCS=true webpack serve",
     "build:dist": "rimraf ./coverage && BUILD_DIST=true webpack",
     "build:docs": "rimraf ./examples/dist && BUILD_DOCS=true webpack",
-    "build:lib": "rimraf ./{lib,coverage} && babel src --out-dir lib",
-    "build": "npm run build:dist -s && npm run build:lib -s && npm run build:docs -s",
+    "build": "npm run build:dist -s && npm run build:docs -s",
     "test:ci": "npm run test:karma -s",
     "test": "npm run build -s && npm run test:karma -s",
     "posttest": "npm run lint -s",

--- a/spec/api.spec.js
+++ b/spec/api.spec.js
@@ -1,4 +1,4 @@
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 
 describe('Editable', function () {
   let editable, div

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash.clonedeep'
 import config from '../src/config'
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 
 describe('Editable configuration', function () {
 

--- a/spec/create-default-events.spec.js
+++ b/spec/create-default-events.spec.js
@@ -1,7 +1,7 @@
 import rangy from 'rangy'
 
 import Cursor from '../src/cursor'
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 
 describe('Default Events', function () {
 

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -3,7 +3,7 @@ import rangy from 'rangy'
 import * as content from '../src/content'
 import Cursor from '../src/cursor'
 import Keyboard from '../src/keyboard'
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 import Selection from '../src/selection'
 const {key} = Keyboard
 

--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -1,5 +1,5 @@
 import rangy from 'rangy'
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 import Highlighting from '../src/highlighting'
 import highlightSupport from '../src/highlight-support'
 import WordHighlighter from '../src/plugins/highlighting/text-highlighting'

--- a/spec/spellcheck.spec.js
+++ b/spec/spellcheck.spec.js
@@ -1,7 +1,7 @@
 import rangy from 'rangy'
 import sinon from 'sinon'
 
-import Editable from '../src/core'
+import {Editable} from '../src/core'
 import Highlighting from '../src/highlighting'
 import Cursor from '../src/cursor'
 import {createElement} from '../src/util/dom'

--- a/src/core.js
+++ b/src/core.js
@@ -35,7 +35,7 @@ import {domArray} from './util/dom'
  *
  * @class Editable
  */
-export default class Editable {
+export class Editable {
 
   constructor (instanceConfig) {
     const defaultInstanceConfig = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
   output: {
     library: dist ? 'Editable' : undefined,
     libraryTarget: 'umd',
-    libraryExport: 'default',
+    libraryExport: 'Editable',
     path: __dirname,
     filename: '[name].js'
   },


### PR DESCRIPTION
### 💥 Breaking Change
- The source code doesn't get transpiled into the `lib` directory anymore.
  You'll either need to require `dist/editable.js` or set up your build system to support ES modules. See the comment below.
  This simplifies the usage together with npm link as there's a build step less in between.
  The files in the dist folder should work as before.
- The module exports changed from a default export to a named export.
  For Import:
  change
  ```
  import Editable from '@livingdocs/editable.js'
  ```
  to
  ```
  import {Editable} from '@livingdocs/editable.js'
  ```
  
  For require:
  change
  ```
  const Editable = require('@livingdocs/editable.js')
  ```
  to
  ```
  const {Editable} = require('@livingdocs/editable.js')
  ```
