### PR TITLE
Fix newline behavior

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -92,6 +92,12 @@ export function extractContent (element, keepUiElements) {
   clone.innerHTML = innerHtml
   unwrapInternalNodes(clone, keepUiElements)
 
+  // Remove line breaks at the beginning of a content block
+  removeWhitespaces(clone, 'firstChild')
+
+  // Remove line breaks at the end of a content block
+  removeWhitespaces(clone, 'lastChild')
+
   return clone.innerHTML
 }
 
@@ -130,6 +136,21 @@ export function cloneRangeContents (range) {
   const fragment = document.createDocumentFragment()
   while (parent.childNodes.length) fragment.appendChild(parent.childNodes[0])
   return fragment
+}
+
+function removeWhitespaces (node, type) {
+  let elem
+  while ((elem = node[type])) {
+    if (elem.nodeType === nodeType.textNode) {
+      if (/^\s+$/.test(elem.textContent)) node.removeChild(elem)
+      else break
+    } else if (elem.nodeName === 'BR') {
+      elem.remove()
+    } else {
+      if (elem[type]) removeWhitespaces(elem, type)
+      break
+    }
+  }
 }
 
 // Remove elements that were inserted for internal or user interface purposes

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -44,11 +44,29 @@ export default function createDefaultBehavior (editable) {
     },
 
     newline (element, cursor) {
-
+      // When the cursor is at the text end, we'll need to add an empty text node
+      // after the br tag to ensure that the cursor shows up on the next line
       if (cursor.isAtTextEnd()) {
-        const trailingBr = document.createElement('br')
-        trailingBr.setAttribute('data-editable', 'remove')
-        cursor.insertBefore(trailingBr)
+        // We need to wrap the newline, so it can get deleted
+        // together with the null escape character
+        const spanWithTextNode = document.createElement('span')
+        spanWithTextNode.setAttribute('data-editable', 'unwrap')
+
+        // The null escape character gets wrapped in another span,
+        // so it gets removed automatically.
+        // contenteditable=false prevents a focus of the span
+        // and therefore also prevents content from getting written into it.
+        // If this attribute is defined on the parent wrapper element,
+        // the cursor positioning behaves weird with deletion of the newline
+        const spacer = document.createElement('span')
+        spacer.setAttribute('data-editable', 'remove')
+        spacer.setAttribute('contenteditable', 'false')
+        spacer.appendChild(document.createTextNode('\u0000'))
+
+        spanWithTextNode.appendChild(document.createElement('br'))
+        spanWithTextNode.appendChild(spacer)
+
+        cursor.insertBefore(spanWithTextNode)
       } else {
         cursor.insertBefore(document.createElement('br'))
       }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -93,17 +93,19 @@ export default class Cursor {
   isAtLastLine () {
     const hostRange = this.win.document.createRange()
     hostRange.selectNodeContents(this.host)
-    const hostCoords = hostRange.getBoundingClientRect()
-    const cursorCoords = getCursorBoundingClientRect(this.range.nativeRange, this.win)
-
+    hostRange.collapse(false)
+    const hostCoords = getRangeBoundingClientRect(hostRange, this.win)
+    const cursorCoords = getRangeBoundingClientRect(this.range.nativeRange, this.win)
     return hostCoords.bottom === cursorCoords.bottom
   }
 
   isAtFirstLine () {
     const hostRange = this.win.document.createRange()
     hostRange.selectNodeContents(this.host)
-    const hostCoords = hostRange.getBoundingClientRect()
-    const cursorCoords = getCursorBoundingClientRect(this.range.nativeRange, this.win)
+    hostRange.collapse(true)
+    const hostCoords = getRangeBoundingClientRect(hostRange, this.win)
+    const cursorCoords = getRangeBoundingClientRect(this.range.nativeRange, this.win)
+    console.log(hostCoords.top, cursorCoords.top)
     return hostCoords.top === cursorCoords.top
   }
 
@@ -345,10 +347,23 @@ export default class Cursor {
   }
 }
 
-function getCursorBoundingClientRect (range, win) {
+
+/**
+* Get position of the range or cursor
+*
+* Can be used to reliably get the boundingClientRect without
+* some any of the drawbacks that the native range has.
+*
+* With the native range.getClientBoundingRect(), newlines are
+* not considered when calculating the position
+*
+* @param {Range} range
+* @param {Window} win
+*/
+function getRangeBoundingClientRect (range, win) {
   if (range.startContainer.nodeType !== elementNode) return range.getBoundingClientRect()
   const el = win.document.createElement('span')
-  el.setAttribute('doc-editable', 'remove')
+  el.setAttribute('doc-editable', 'unwrap')
   range.insertNode(el)
   const coords = el.getBoundingClientRect()
   el.remove()

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -3,6 +3,7 @@ import rangy from 'rangy'
 import {contenteditableSpanBug} from './feature-detection'
 import * as nodeType from './node-type'
 import eventable from './eventable'
+import {unwrapInternalNodes} from './content'
 
 /**
  * The Keyboard module defines an event API for key events.
@@ -36,14 +37,17 @@ export default class Keyboard {
         return this.notify(target, 'esc', event)
 
       case this.key.backspace:
+        unwrapInternalNodes(target, true)
         this.preventContenteditableBug(target, event)
         return this.notify(target, 'backspace', event)
 
       case this.key.delete:
+        unwrapInternalNodes(target, true)
         this.preventContenteditableBug(target, event)
         return this.notify(target, 'delete', event)
 
       case this.key.enter:
+        unwrapInternalNodes(target, true)
         if (event.shiftKey) return this.notify(target, 'shiftEnter', event)
         return this.notify(target, 'enter', event)
 

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -37,16 +37,22 @@ export default class Keyboard {
         return this.notify(target, 'esc', event)
 
       case this.key.backspace:
+        // As a newline element gets wrapped in a span when at the end of a block,
+        // we'll need to unwrap that before to simulate correct delete behavior and not skip lines
         unwrapInternalNodes(target, true)
         this.preventContenteditableBug(target, event)
         return this.notify(target, 'backspace', event)
 
       case this.key.delete:
+        // As a newline element gets wrapped in a span when at the end of a block,
+        // we'll need to unwrap that before to simulate correct delete behavior and not skip lines
         unwrapInternalNodes(target, true)
         this.preventContenteditableBug(target, event)
         return this.notify(target, 'delete', event)
 
       case this.key.enter:
+        // As a newline element gets wrapped in a span when at the end of a block,
+        // we'll need to unwrap that before to simulate correct delete behavior and not skip lines
         unwrapInternalNodes(target, true)
         if (event.shiftKey) return this.notify(target, 'shiftEnter', event)
         return this.notify(target, 'enter', event)
@@ -169,15 +175,15 @@ export default class Keyboard {
       if (firstContentNode !== selectionRange.startContainer) return
     }
 
-    // Now we know, that we have to return at lease the startNodeElement for
+    // Now we know, that we have to return at least the startNodeElement for
     // removal. But it could be, that we also need to remove its parent, e.g.
     // we need to remove <strong> in the following example:
     // <strong><em>|foo</em>bar</strong>baz|
-    const rangeStatingBeforeCurrentElement = selectionRange.cloneRange()
-    rangeStatingBeforeCurrentElement.setStartBefore(startNodeElement)
+    const rangeStartingBeforeCurrentElement = selectionRange.cloneRange()
+    rangeStartingBeforeCurrentElement.setStartBefore(startNodeElement)
 
     return Keyboard.getNodeToRemove(
-      rangeStatingBeforeCurrentElement,
+      rangeStartingBeforeCurrentElement,
       target
     ) || startNodeElement
   }


### PR DESCRIPTION
### Changelog
- 🐛 Do not remove newlines in between child nodes of editable blocks
- 🐛 Do not require two shift+return when appending a new line at the end of an editable block
- 🍬 Trim newlines at the start and end of editable blocks

Behavior Before:
Type text, shift return, shift return, type text. blur
| Before Blur | After Blur  |
|-----------------|:-----------:|
| ![image](https://user-images.githubusercontent.com/431376/127742367-8880f02b-1450-4732-81f9-05178cca4309.png) | ![image](https://user-images.githubusercontent.com/431376/127742345-3ab933c6-9484-454b-b3ec-19acadd9b2da.png)  |

After:
Type text, shift return, type text. blur
Results in 1 exactly newline being present.
And only one shift return is necessary to trigger a newline.


Some tests would still be nice