### PR TITLE
Improve newline behavior

### DIFF
--- a/examples/index.css
+++ b/examples/index.css
@@ -153,8 +153,6 @@ section {
    Example Blocks
    ========================================================================== */
 
-
-
 .example-title {
     font-size: 2rem;
     color: rgba(0, 0, 0, 0.9);
@@ -166,10 +164,6 @@ section {
     font-size: 1.5rem;
     border: 1px solid #eee;
     background-color: #fff;
-}
-
-.block-outline {
-
 }
 
 .code-example {

--- a/examples/index.html
+++ b/examples/index.html
@@ -44,9 +44,7 @@
       </div>
     </section>
 
-
     <!-- Formatting -->
-
     <section class="example-section space-after">
       <div class="section-content">
         <h2 class="example-title">Text Formatting</h2>
@@ -70,7 +68,6 @@
 
 
     <!-- Styling -->
-
     <section class="example-section space-after">
       <div class="section-content">
         <h2 class="example-title">Styling</h2>
@@ -95,9 +92,19 @@
       </div>
     </section>
 
+    <!-- Editable Inline -->
+    <section class="example-section space-after">
+      <div class="section-content">
+        <h2 class="example-title">Inline editables</h2>
+        <div class="inline-example example-sheet">
+          <span style="margin-right: 20px;">
+            Some inline editable element.
+          </span>
+        </div>
+    </section>
+
 
     <!-- Highlight -->
-
     <section class="example-section space-after">
       <div class="section-content">
         <h2 class="example-title">Highlighting</h2>

--- a/examples/index.js
+++ b/examples/index.js
@@ -11,11 +11,11 @@ const editable = new Editable({browserSpellcheck: false})
 editable.add('.paragraph-example p')
 eventList(editable)
 
+// Text formatting toolbar
 editable.add('.formatting-example p')
 setupTooltip()
 
 editable.add('.styling-example p')
-
 const secondExample = document.querySelector('.formatting-example p')
 updateCode(secondExample)
 
@@ -33,6 +33,8 @@ document.querySelector('select[name="editable-styles"]')
     }
   })
 
+// Inline element
+editable.add('.inline-example span')
 
 // IFrame
 // ------

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -245,31 +245,20 @@ describe('Dispatcher', function () {
         expect(elem.innerHTML).to.equal('<br>\uFEFF')
       })
 
-      it('creates a nested br element with a data-editable="unwrap" attribute', () => {
+      it('appends a zero-width space after the br tag to force a line break', () => {
         typeKeys(elem, 'foobar')
         shiftReturn(elem)
         expect(elem.innerHTML).to.equal(
-          `\uFEFF` +
-          `foobar` +
-          `<span data-editable="unwrap">` +
-            `<br><span data-editable="remove" contenteditable="false">\uFEFF</span>` +
-          `</span>`
+          `\uFEFFfoobar<br>\uFEFF`
         )
       })
 
-      it('removes the nested br element when adding a newline afterwards', () => {
+      it('does not append another zero-width space when one is present already', () => {
         typeKeys(elem, 'foobar')
         shiftReturn(elem)
         shiftReturn(elem)
         expect(elem.innerHTML).to.equal(
-          `\uFEFF` +
-          `foobar` +
-          // this is the nested br element that got unwrapped
-          `<br>` +
-          // This is the new nested newline of the second shift + return
-          `<span data-editable="unwrap">` +
-            `<br><span data-editable="remove" contenteditable="false">\uFEFF</span>` +
-          `</span>`
+          `\uFEFFfoobar<br><br>\uFEFF`
         )
       })
     })

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -86,7 +86,7 @@ describe('Dispatcher', function () {
         elem.blur()
         expect(elem.textContent).to.equal('')
         elem.focus()
-        expect(elem.textContent).to.equal('\u0000')
+        expect(elem.textContent).to.equal('\uFEFF')
       })
 
       it('should not add an empty text node if there is content', function () {
@@ -98,7 +98,7 @@ describe('Dispatcher', function () {
 
       it('removes the empty text node again on blur', function () {
         elem.focus()
-        expect(elem.textContent).to.equal('\u0000')
+        expect(elem.textContent).to.equal('\uFEFF')
         elem.blur()
         expect(elem.textContent).to.equal('')
       })
@@ -242,17 +242,17 @@ describe('Dispatcher', function () {
       it('fires newline when shift + enter is pressed', (done) => {
         on('newline', () => done())
         shiftReturn(elem)
-        expect(elem.innerHTML).to.equal('<br>\u0000')
+        expect(elem.innerHTML).to.equal('<br>\uFEFF')
       })
 
       it('creates a nested br element with a data-editable="unwrap" attribute', () => {
         typeKeys(elem, 'foobar')
         shiftReturn(elem)
         expect(elem.innerHTML).to.equal(
-          `\u0000` +
+          `\uFEFF` +
           `foobar` +
           `<span data-editable="unwrap">` +
-            `<br><span data-editable="remove" contenteditable="false">\u0000</span>` +
+            `<br><span data-editable="remove" contenteditable="false">\uFEFF</span>` +
           `</span>`
         )
       })
@@ -262,13 +262,13 @@ describe('Dispatcher', function () {
         shiftReturn(elem)
         shiftReturn(elem)
         expect(elem.innerHTML).to.equal(
-          `\u0000` +
+          `\uFEFF` +
           `foobar` +
           // this is the nested br element that got unwrapped
           `<br>` +
           // This is the new nested newline of the second shift + return
           `<span data-editable="unwrap">` +
-            `<br><span data-editable="remove" contenteditable="false">\u0000</span>` +
+            `<br><span data-editable="remove" contenteditable="false">\uFEFF</span>` +
           `</span>`
         )
       })

--- a/src/content.js
+++ b/src/content.js
@@ -14,7 +14,6 @@ function restoreRange (host, range, func) {
 const zeroWidthSpace = /\u200B/g
 const zeroWidthNonBreakingSpace = /\uFEFF/g
 const whitespaceExceptSpace = /[^\S ]/g
-const nullEscapeCharacter = /\u0000/g // eslint-disable-line no-control-regex
 
 // Clean up the Html.
 export function tidyHtml (element) {
@@ -84,7 +83,6 @@ export function extractContent (element, keepUiElements) {
     ? getInnerHtmlOfFragment(element)
     : element.innerHTML
   )
-    .replace(nullEscapeCharacter, '') // Used to generate empty text nodes on focus event.
     .replace(zeroWidthNonBreakingSpace, '') // Used for forcing inline elements to have a height
     .replace(zeroWidthSpace, '<br>') // Used for cross-browser newlines
 

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -23,12 +23,14 @@ export default function createDefaultBehavior (editable) {
   */
 
   return {
+    /** @param {HTMLElement} element */
     focus (element) {
-      // Add an empty text node if the editable is empty to force it to have height
+      if (!parser.isVoid(element)) return
+
+      // Add an zero width space if the editable is empty to force it to have a height
       // E.g. Firefox does not render empty block elements
       //   and most browsers do not render empty inline elements.
-      if (!parser.isVoid(element)) return
-      element.appendChild(document.createTextNode('\u0000'))
+      element.appendChild(document.createTextNode('\uFEFF'))
     },
 
     blur (element) {
@@ -61,7 +63,7 @@ export default function createDefaultBehavior (editable) {
         const spacer = document.createElement('span')
         spacer.setAttribute('data-editable', 'remove')
         spacer.setAttribute('contenteditable', 'false')
-        spacer.appendChild(document.createTextNode('\u0000'))
+        spacer.appendChild(document.createTextNode('\uFEFF'))
 
         spanWithTextNode.appendChild(document.createElement('br'))
         spanWithTextNode.appendChild(spacer)

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -3,7 +3,6 @@ import rangy from 'rangy'
 import {contenteditableSpanBug} from './feature-detection'
 import * as nodeType from './node-type'
 import eventable from './eventable'
-import {unwrapInternalNodes} from './content'
 
 /**
  * The Keyboard module defines an event API for key events.
@@ -37,23 +36,14 @@ export default class Keyboard {
         return this.notify(target, 'esc', event)
 
       case this.key.backspace:
-        // As a newline element gets wrapped in a span when at the end of a block,
-        // we'll need to unwrap that before to simulate correct delete behavior and not skip lines
-        unwrapInternalNodes(target, true)
         this.preventContenteditableBug(target, event)
         return this.notify(target, 'backspace', event)
 
       case this.key.delete:
-        // As a newline element gets wrapped in a span when at the end of a block,
-        // we'll need to unwrap that before to simulate correct delete behavior and not skip lines
-        unwrapInternalNodes(target, true)
         this.preventContenteditableBug(target, event)
         return this.notify(target, 'delete', event)
 
       case this.key.enter:
-        // As a newline element gets wrapped in a span when at the end of a block,
-        // we'll need to unwrap that before to simulate correct delete behavior and not skip lines
-        unwrapInternalNodes(target, true)
         if (event.shiftKey) return this.notify(target, 'shiftEnter', event)
         return this.notify(target, 'enter', event)
 


### PR DESCRIPTION
### Changelog
- 🐛  Use zero width spaces instead of null escape characters as they caused issues with some fonts
- 🐛 Use a more elegant solution to force a line break after a `<br>` tag. Previously backspace deleted a character too much when a newline at the end of a block got deleted.