### PR TITLE
Fix copy-paste of bold text

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,8 @@ module.exports = function (config) {
 
     plugins: [
       'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-safari-launcher',
       'karma-coverage',
       'karma-mocha',
       'karma-sourcemap-loader',

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -353,5 +353,20 @@ describe('Dispatcher', function () {
         expect(position).to.equal('end')
       })
     })
+
+    describe('on paste', function () {
+
+      it('inserts clipboard content', (done) => {
+        on('paste', (block, blocks) => {
+          expect(blocks).to.deep.equal(['a <strong>bold</strong> test'])
+          done()
+        })
+
+        const clipboardData = new DataTransfer()
+        clipboardData.setData('text/html', 'a <strong>bold</strong> test')
+        const evt = new ClipboardEvent('paste', {clipboardData, bubbles: true})
+        elem.dispatchEvent(evt)
+      })
+    })
   })
 })

--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -356,7 +356,19 @@ describe('Dispatcher', function () {
 
     describe('on paste', function () {
 
-      it('inserts clipboard content', (done) => {
+      it('inserts plain text clipboard content', (done) => {
+        on('paste', (block, blocks) => {
+          expect(blocks).to.deep.equal(['a plain test'])
+          done()
+        })
+
+        const clipboardData = new DataTransfer()
+        clipboardData.setData('text/plain', 'a plain test')
+        const evt = new ClipboardEvent('paste', {clipboardData, bubbles: true})
+        elem.dispatchEvent(evt)
+      })
+
+      it('inserts formatted clipboard content', (done) => {
         on('paste', (block, blocks) => {
           expect(blocks).to.deep.equal(['a <strong>bold</strong> test'])
           done()

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -25,7 +25,7 @@ export function updateConfig (conf) {
   rules.splitIntoBlocks.forEach((name) => { splitIntoBlocks[name] = true })
 }
 
-export function paste (element, cursor, clipboardContent, callback) {
+export function paste (element, cursor, clipboardContent) {
   const document = element.ownerDocument
   element.setAttribute(config.pastingAttribute, true)
 
@@ -38,7 +38,7 @@ export function paste (element, cursor, clipboardContent, callback) {
   const blocks = parseContent(pasteHolder)
 
   element.removeAttribute(config.pastingAttribute)
-  callback(blocks, cursor)
+  return {blocks, cursor}
 }
 
 /**

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -25,46 +25,20 @@ export function updateConfig (conf) {
   rules.splitIntoBlocks.forEach((name) => { splitIntoBlocks[name] = true })
 }
 
-export function paste (element, cursor, callback) {
+export function paste (element, cursor, clipboardContent, callback) {
   const document = element.ownerDocument
   element.setAttribute(config.pastingAttribute, true)
 
   if (cursor.isSelection) cursor = cursor.deleteContent()
 
-  // Create a placeholder and set the focus to the pasteholder
-  // to redirect the browser pasting into the pasteholder.
-  cursor.save()
-  const pasteHolder = injectPasteholder(document)
-  pasteHolder.focus()
-
-  // Use a timeout to give the browser some time to paste the content.
-  // After that grab the pasted content, filter it and restore the focus.
-  setTimeout(() => {
-    const blocks = parseContent(pasteHolder)
-    pasteHolder.remove()
-    element.removeAttribute(config.pastingAttribute)
-    cursor.restore()
-    callback(blocks, cursor)
-  }, 0)
-}
-
-/**
- * @param { Document } document
- */
-export function injectPasteholder (document) {
+  // Create a placeholder to help parse HTML
   const pasteHolder = document.createElement('div')
-  pasteHolder.setAttribute('contenteditable', true)
-  pasteHolder.style.position = 'fixed'
-  pasteHolder.style.right = '5px'
-  pasteHolder.style.top = '50%'
-  pasteHolder.style.width = '1px'
-  pasteHolder.style.height = '1px'
-  pasteHolder.style.overflow = 'hidden'
-  pasteHolder.style.outline = 'none'
+  pasteHolder.innerHTML = clipboardContent
 
-  document.body.appendChild(pasteHolder)
+  const blocks = parseContent(pasteHolder)
 
-  return pasteHolder
+  element.removeAttribute(config.pastingAttribute)
+  callback(blocks, cursor)
 }
 
 /**

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -128,6 +128,7 @@ export default class Dispatcher {
         const block = this.getEditableBlockByEvent(evt)
         if (!block) return
         const afterPaste = (blocks, cursor) => {
+          evt.preventDefault()
           if (blocks.length) {
             this.notify('paste', block, blocks, cursor)
 
@@ -140,7 +141,8 @@ export default class Dispatcher {
         }
 
         const cursor = this.selectionWatcher.getFreshSelection()
-        clipboard.paste(block, cursor, afterPaste)
+        const clipboardContent = evt.clipboardData.getData('text/html')
+        clipboard.paste(block, cursor, clipboardContent, afterPaste)
       })
       .setupDocumentListener('input', function inputListener (evt) {
         const block = this.getEditableBlockByEvent(evt)

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -127,22 +127,21 @@ export default class Dispatcher {
       .setupDocumentListener('paste', function pasteListener (evt) {
         const block = this.getEditableBlockByEvent(evt)
         if (!block) return
-        const afterPaste = (blocks, cursor) => {
-          evt.preventDefault()
-          if (blocks.length) {
-            this.notify('paste', block, blocks, cursor)
 
-            // The input event does not fire when we process the content manually
-            // and insert it via script
-            this.notify('change', block)
-          } else {
-            cursor.setVisibleSelection()
-          }
+        evt.preventDefault()
+        const selection = this.selectionWatcher.getFreshSelection()
+        const clipboardContent = evt.clipboardData.getData('text/html') || evt.clipboardData.getData('text/plain')
+
+        const {blocks, cursor} = clipboard.paste(block, selection, clipboardContent)
+        if (blocks.length) {
+          this.notify('paste', block, blocks, cursor)
+
+          // The input event does not fire when we process the content manually
+          // and insert it via script
+          this.notify('change', block)
+        } else {
+          cursor.setVisibleSelection()
         }
-
-        const cursor = this.selectionWatcher.getFreshSelection()
-        const clipboardContent = evt.clipboardData.getData('text/html')
-        clipboard.paste(block, cursor, clipboardContent, afterPaste)
       })
       .setupDocumentListener('input', function inputListener (evt) {
         const block = this.getEditableBlockByEvent(evt)


### PR DESCRIPTION
## Motivation

When copy-pasting formatted text which contains a `<strong>` tag, the tag would get lost in Chrome/Safari (but not in Firefox).

This is fixed by changing the method of retrieving pasted text from the clipboard.
Before: A hidden element with `contenteditable` attribute is focused on paste, then the clipboard content is extracted from there.
New: Clipboard content is taken from the [ClipboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/clipboardData).

The new way seems to work reliably in all browsers and was also manually tested in Chrome, Firefox, Safari, Edge (all on macOS).

I'm not sure why specifically the `<strong>` tag was broken, maybe it's related to [this chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=546461).

After pasting, editable.js filters tags based on the allowedElements configuration. This PR does not change anything about the filtering, but note that the `<strong>` tag is [allowed by default](https://github.com/livingdocsIO/editable.js/blob/v3.0.1/src/config.js#L46) and the bug was not related to this.

## Screenshots

(the first line is copy-pasted to the second line)

Before fix:
![Screenshot 2021-09-07 at 14 22 01](https://user-images.githubusercontent.com/47303530/132345091-ff9114a3-14ed-41d1-bfea-5f90020b5f91.png)

After fix:
![Screenshot 2021-09-07 at 14 21 35](https://user-images.githubusercontent.com/47303530/132345102-14276047-390c-43ad-9db9-e5493961e6f5.png)

## Changelog

- 🐞- Copy-pasting formatted text which contains a `<strong>` tag is now working as expected on all browsers.