### PR TITLE
Fix endless loop in text-search

### DIFF
--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -103,6 +103,14 @@ describe('Highlighting', function () {
       expect(firstMatch.startIndex).to.equal(5)
       expect(firstMatch.endIndex).to.equal(10)
     })
+
+    it('does not go into an endless loop without a marker node', function () {
+      const blockText = 'Mehr als 90 Prozent der Fälle in Grossbritannien in den letzten vier Wochen gehen auf die Delta-Variante zurück. Anders als bei vorangegangenen Wellen scheinen sich jedoch die Fallzahlen von den Todesfällen und Hospitalisierungen zu entkoppeln.'
+      const text = ''
+      const textSearch = new WordHighlighter(null, 'text')
+      const matches = textSearch.findMatches(blockText, [text])
+      expect(matches).to.equal(undefined)
+    })
   })
 
   describe('highlightSupport', function () {

--- a/src/plugins/highlighting/text-highlighting.js
+++ b/src/plugins/highlighting/text-highlighting.js
@@ -7,8 +7,22 @@ export default class WordHighlighting {
     this.matchMode = matchMode
   }
 
+  isElement (obj) {
+    try {
+      // Using W3 DOM2 (works for FF, Opera and Chrome)
+      return obj instanceof HTMLElement
+    } catch (e) {
+      // Browsers not supporting W3 DOM2 don't have HTMLElement and
+      // an exception is thrown and we end up here. Testing some
+      // properties that all elements have (works on IE7)
+      return (typeof obj === 'object') &&
+        (obj.nodeType === 1) && (typeof obj.style === 'object') &&
+        (typeof obj.ownerDocument === 'object')
+    }
+  }
+
   findMatches (text, highlights) {
-    if (!text) return
+    if (!text || text === '' || !this.isElement(this.marker)) return
 
     if (highlights && highlights.length > 0) {
       return this.searchMatches(text, highlights)
@@ -21,11 +35,7 @@ export default class WordHighlighting {
       : createHighlightRegex
 
     const regex = createRegex(highlights)
-    const matches = []
-    let match
-    while ((match = regex.exec(text))) {
-      matches.push(match)
-    }
+    const matches = [...text.matchAll(regex)]
 
     return matches.map((entry) => this.prepareMatch(entry))
   }


### PR DESCRIPTION
## Motivation

In the multiline editable selection from the framework sometimes the case arises that the editable host is undefined and in turn the marker node in the text search is undefined. In that case the code went into an endless loop and crashed the browser.

## Changelog

### 🐞 Abort text search if marker node is undefined

If the marker node in a text search is not set, the search should not be performed and abort early.