### PR TITLE
Fix cursor move rounding issues

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -96,7 +96,7 @@ export default class Cursor {
     hostRange.collapse(false)
     const hostCoords = getRangeBoundingClientRect(hostRange, this.win)
     const cursorCoords = getRangeBoundingClientRect(this.range.nativeRange, this.win)
-    return hostCoords.bottom === cursorCoords.bottom
+    return isCloseTo(hostCoords.bottom, cursorCoords.bottom)
   }
 
   isAtFirstLine () {
@@ -105,7 +105,7 @@ export default class Cursor {
     hostRange.collapse(true)
     const hostCoords = getRangeBoundingClientRect(hostRange, this.win)
     const cursorCoords = getRangeBoundingClientRect(this.range.nativeRange, this.win)
-    return hostCoords.top === cursorCoords.top
+    return isCloseTo(hostCoords.top, cursorCoords.top)
   }
 
   isAtBeginning () {
@@ -367,4 +367,10 @@ function getRangeBoundingClientRect (range, win) {
   const coords = el.getBoundingClientRect()
   el.remove()
   return coords
+}
+
+function isCloseTo (a, b) {
+  if (a === b) return true
+  if (Math.abs(a - b) <= 2) return true
+  return false
 }


### PR DESCRIPTION
Partially fixes #244 

### Changelog
- 🐛 Fix block focus events when using a browser zoom. There were rounding issues

Safari still has an issue with newlines at the end of an html element.

This doesn't work:
```html
<p>
  Hello
</p>
<p>
  World
</p>
```

And this is working:
```html
<p>Hello</p>
<p>World</p>
```