### PR TITLE
Remove whitespaces at start and end of blocks during initialization

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -8,14 +8,14 @@ const editable = new Editable({browserSpellcheck: false})
 
 // Paragraph
 // ---------
-editable.add('.paragraph-example p')
+editable.enable('.paragraph-example p', true)
 eventList(editable)
 
 // Text formatting toolbar
-editable.add('.formatting-example p')
+editable.enable('.formatting-example p', true)
 setupTooltip()
 
-editable.add('.styling-example p')
+editable.enable('.styling-example p', true)
 const secondExample = document.querySelector('.formatting-example p')
 updateCode(secondExample)
 

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -58,6 +58,12 @@ describe('Content', function () {
       content.normalizeTags(actual)
       expect(actual.innerHTML).to.equal(expected.innerHTML)
     })
+
+    it('removes whitespaces at the start and end', function () {
+      const elem = createElement('<div> Hello <strong>world</strong>&nbsp; &nbsp;</div>')
+      content.normalizeTags(elem)
+      expect(elem.innerHTML).to.equal('Hello <strong>world</strong>')
+    })
   })
 
   describe('normalizeWhitespace()', function () {

--- a/src/content.js
+++ b/src/content.js
@@ -29,6 +29,12 @@ export function tidyHtml (element) {
 export function normalizeTags (element) {
   const fragment = document.createDocumentFragment()
 
+  // Remove line breaks at the beginning of a content block
+  removeWhitespaces(element, 'firstChild')
+
+  // Remove line breaks at the end of a content block
+  removeWhitespaces(element, 'lastChild')
+
   for (const node of element.childNodes) {
     // skip empty tags, so they'll get removed
     if (node.nodeName !== 'BR' && !node.textContent) continue
@@ -136,7 +142,7 @@ export function cloneRangeContents (range) {
   return fragment
 }
 
-function removeWhitespaces (node, type) {
+function removeWhitespaces (node, type, firstCall = true) {
   let elem
   while ((elem = node[type])) {
     if (elem.nodeType === nodeType.textNode) {
@@ -145,10 +151,17 @@ function removeWhitespaces (node, type) {
     } else if (elem.nodeName === 'BR') {
       elem.remove()
     } else {
-      if (elem[type]) removeWhitespaces(elem, type)
+      if (elem[type]) removeWhitespaces(elem, type, false)
       break
     }
   }
+
+  if (!firstCall) return
+  elem = node[type]
+  if (elem?.nodeType !== nodeType.textNode) return
+  // Remove whitespaces at the end or start of a block with content
+  //   e.g. '  Hello world' > 'Hello World'
+  elem.textContent = elem.textContent.replace(type.startsWith('last') ? /\s+$/ : /^\s+/, '')
 }
 
 // Remove elements that were inserted for internal or user interface purposes


### PR DESCRIPTION
### Motivation
Content blocks were able to start with spaces before a word. This causes issues in safari as it's not possible to create cursors and get the correct position at the end.
Removing them before initialization results in more tidy content and is most likely ok.

`<p contenteditable=true>      Hello World</p>`
will result in
`<p contenteditable=true>Hello World</p>`

but only when `editable.enable(elem, true)` is used.

During extraction we apply the same logic but always.

This is another fix for #244

### Changelog
- 🐛 To prevent safari getClientBoundingRect issues, we'll need to remove whitespaces at the start and end of a content block

