### PR TITLE
Fix: Revert to jQuery-behavior for link attrs update

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -269,6 +269,27 @@ describe('Selection', function () {
         const linkTags = this.selection.getTagsByName('a')
         expect(linkTags.length).to.equal(0)
       })
+
+      it('sets class attribute', function () {
+        this.selection.link('https://livingdocs.io', {class: 'baz'})
+        const linkTags = this.selection.getTagsByName('a')
+        const html = getHtml(linkTags[0])
+        expect(html).to.equal('<a class="baz" href="https://livingdocs.io">foobar</a>')
+      })
+
+      it('removes class attribute when set to null', function () {
+        this.selection.link('https://livingdocs.io', {class: null})
+        const linkTags = this.selection.getTagsByName('a')
+        const html = getHtml(linkTags[0])
+        expect(html).to.equal('<a href="https://livingdocs.io">foobar</a>')
+      })
+
+      it('does not modify class attribute when set to undefined', function () {
+        this.selection.link('https://livingdocs.io', {class: undefined})
+        const linkTags = this.selection.getTagsByName('a')
+        const html = getHtml(linkTags[0])
+        expect(html).to.equal('<a class="foo bar" href="https://livingdocs.io">foobar</a>')
+      })
     })
 
   })

--- a/src/selection.js
+++ b/src/selection.js
@@ -78,7 +78,15 @@ export default class Selection extends Cursor {
   link (href, attrs = {}) {
     if (href) attrs.href = href
     const link = this.createElement(config.linkMarkup.name, config.linkMarkup.attribs)
-    for (const key in attrs) link.setAttribute(key, attrs[key])
+    for (const key in attrs) {
+      const value = attrs[key]
+      if (value === undefined) continue
+      if (value === null) {
+        link.removeAttribute(key)
+      } else {
+        link.setAttribute(key, value)
+      }
+    }
     this.forceWrap(link)
   }
 


### PR DESCRIPTION
Revert to [same behavior as jQuery's .attr()](https://github.com/jquery/jquery/blob/3.6.0/src/attributes/attr.js#L49-L53) for updating attributes in `link()`:
- `null` value removes attribute
- `undefined` value does not modify attribute

This reverts to the behavior before the migration away from jQuery (83e512f5d4).

This fixes an issue in livingdocs-editor, where the following call would render attributes incorrectly:
```js
selection.link("https://bluewin.ch", {
  rel: null,
  target: null
})
```

Result before fix: `<a target="null" rel="null" href="https://bluewin.ch">relative link</a>`

Result after fix: `<a href="https://bluewin.ch">relative link</a>`