### PR TITLE
fix isElement function

### DIFF
--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -111,6 +111,25 @@ describe('Highlighting', function () {
       const matches = textSearch.findMatches(blockText, [text])
       expect(matches).to.equal(undefined)
     })
+
+    it('does not go into an endless loop without a html marker node', function () {
+      const blockText = 'Mehr als 90 Prozent der Fälle in Grossbritannien in den letzten vier Wochen gehen auf die Delta-Variante zurück. Anders als bei vorangegangenen Wellen scheinen sich jedoch die Fallzahlen von den Todesfällen und Hospitalisierungen zu entkoppeln.'
+      const text = ''
+      const textSearch = new WordHighlighter('something', 'text')
+      const matches = textSearch.findMatches(blockText, [text])
+      expect(matches).to.equal(undefined)
+    })
+
+    it('handle the marker with other ownerdocument correctly', function () {
+      const blockText = 'Mehr als 90 Prozent'
+      const text = 'Mehr als 90 Prozent'
+      const ifrm = window.document.createElement('iframe')
+      window.document.body.append(ifrm)
+      const markerNode = createElement('<span class="highlight"></span>', ifrm.contentWindow)
+      const textSearch = new WordHighlighter(markerNode, 'text')
+      const matches = textSearch.findMatches(blockText, [text])
+      expect(matches[0].match).to.equal(text)
+    })
   })
 
   describe('highlightSupport', function () {

--- a/src/plugins/highlighting/text-highlighting.js
+++ b/src/plugins/highlighting/text-highlighting.js
@@ -9,8 +9,8 @@ export default class WordHighlighting {
 
   isElement (obj) {
     try {
-      // Using W3 DOM2 (works for FF, Opera and Chrome)
-      return obj instanceof HTMLElement
+      if (!obj) return false
+      return obj instanceof obj.ownerDocument?.defaultView.HTMLElement
     } catch (e) {
       // Browsers not supporting W3 DOM2 don't have HTMLElement and
       // an exception is thrown and we end up here. Testing some


### PR DESCRIPTION
# Motivation
The isElement function has added a direct dependency to the ownerDocument. This is the reason why for the spellcheck the instanceof will fail. 

# Changelog
🐞 support marker in highlighting with other ownerdocument

