### PR TITLE
Allow formats to be set over links if the beginning or end is at a boundary

### DIFF
--- a/examples/index.css
+++ b/examples/index.css
@@ -28,6 +28,13 @@ body {
 }
 
 /*
+    Make trailing whitespaces visible since they can be quite confusing.
+*/
+[data-editable] {
+    white-space: pre-wrap;
+  }
+
+/*
  * Remove text-shadow in selection highlight: h5bp.com/i
  * These selection declarations have to be separate.
  * Customize the background color to match your design.

--- a/examples/index.html
+++ b/examples/index.html
@@ -28,12 +28,8 @@
         <h2 class="example-title">An editable paragraph</h2>
 
         <div class="paragraph-example example-sheet">
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed ante dapibus diam. Sed nisi.
-          </p>
-          <p>
-            Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla.
-          </p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed ante dapibus diam. Sed nisi.</p>
+          <p>Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla.</p>
         </div>
 
         <div>
@@ -50,16 +46,12 @@
         <h2 class="example-title">Text Formatting</h2>
 
         <div class="formatting-example example-sheet">
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero.
-          </p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero.</p>
         </div>
 
         <div class="code-example">
           <h3>HTML</h3>
-<pre><code class="formatting-code-js language-markup">&lt;p&gt;
-  Lorem ipsum dolor sit amet...
-&lt;/p&gt;</code></pre>
+<pre><code class="formatting-code-js language-markup">&lt;p&gt;Lorem ipsum dolor sit amet...&lt;/p&gt;</code></pre>
 
         </div>
 
@@ -73,9 +65,7 @@
         <h2 class="example-title">Styling</h2>
 
         <div class="styling-example example-sheet">
-          <p class="example-style-default">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero.
-          </p>
+          <p class="example-style-default">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero.</p>
         </div>
 
         <div class="code-example">
@@ -97,9 +87,7 @@
       <div class="section-content">
         <h2 class="example-title">Inline editables</h2>
         <div class="inline-example example-sheet">
-          <span style="margin-right: 20px;">
-            Some inline editable element.
-          </span>
+          <span style="margin-right: 20px;">Some inline editable element.</span>
         </div>
     </section>
 
@@ -110,9 +98,7 @@
         <h2 class="example-title">Highlighting</h2>
 
         <div class="highlighting-example example-sheet">
-          <p>
-            Is everybody happy? I want everybody to be happy. I know I'm happy.
-          </p>
+          <p>Is everybody happy? I want everybody to be happy. I know I'm happy.</p>
         </div>
       </div>
     </section>
@@ -150,9 +136,7 @@
         <h2 class="example-title">Copy and Paste</h2>
 
         <div class="pasting-example example-sheet">
-          <p>
-            Paste here...
-          </p>
+          <p>Paste here...</p>
         </div>
       </div>
     </section>

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -293,7 +293,7 @@ describe('Content', function () {
     it('works with a partially selected tag', function () {
       // <div>|a<em>b|b</em></div>
       const host = createElement('<div>a<em>bb</em></div>')
-      this.range.setStart(host.firstChild, 0)
+      this.range.setStart(host.querySelector('em').firstChild, 0)
       this.range.setEnd(host.querySelector('em').firstChild, 1)
 
       this.range = content.deleteCharacter(host, this.range, 'b')

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -290,6 +290,71 @@ describe('Selection', function () {
         const html = getHtml(linkTags[0])
         expect(html).to.equal('<a class="foo bar" href="https://livingdocs.io">foobar</a>')
       })
+
+      describe('with bold:', function () {
+        beforeEach(function () {
+          this.oldBoldMarkup = config.boldMarkup
+          config.boldMarkup = {
+            type: 'tag',
+            name: 'strong',
+            attribs: {
+              'class': 'foo'
+            }
+          }
+        })
+
+        afterEach(function () {
+          config.boldMarkup = this.oldBoldMarkup
+        })
+
+        it('toggles a link bold', function () {
+          this.selection.link('https://livingdocs.io')
+          this.selection.makeBold()
+          const boldTags = this.selection.getTagsByName('strong')
+          const html = getHtml(boldTags[0])
+          expect(html).to.equal('<strong class="foo"><a class="foo bar" href="https://livingdocs.io">foobar</a></strong>')
+        })
+
+        it('toggles a link bold in a selection with text after', function () {
+          // set foo in <div>|foo|bar</div> as the selection
+          let range = rangy.createRange()
+          range.setStart(this.oneWord.firstChild, 0)
+          range.setEnd(this.oneWord.firstChild, 3)
+          let selection = new Selection(this.oneWord, range)
+          // link foo
+          selection.link('https://livingdocs.io')
+          // select 1 char more to the right (b)
+          range = rangy.createRange()
+          // Note: we need to use firstChild twice to get the textNode inside the a tag which is
+          // also what the normal browser select behavior does
+          range.setStart(this.oneWord.firstChild.firstChild, 0)
+          range.setEnd(this.oneWord.lastChild, 1)
+          selection = new Selection(this.oneWord, range)
+          // make link + b char bold
+          selection.toggleBold()
+          const html = getHtml(this.oneWord)
+          expect(html).to.equal('<div><strong class="foo"><a class="foo bar" href="https://livingdocs.io">foo</a>b</strong>ar</div>')
+        })
+
+        it('toggles a link bold in a selection with text before', function () {
+          // set bar in <div>foo|bar|</div> as the selection
+          let range = rangy.createRange()
+          range.setStart(this.oneWord.firstChild, 3)
+          range.setEnd(this.oneWord.firstChild, 6)
+          let selection = new Selection(this.oneWord, range)
+          // link bar
+          selection.link('https://livingdocs.io')
+          // select 1 char more to the left (o)
+          range = rangy.createRange()
+          range.setStart(this.oneWord.firstChild, 2)
+          range.setEnd(this.oneWord.lastChild.firstChild, 3)
+          selection = new Selection(this.oneWord, range)
+          // make o char + link bold
+          selection.toggleBold()
+          const html = getHtml(this.oneWord)
+          expect(html).to.equal('<div>fo<strong class="foo">o<a class="foo bar" href="https://livingdocs.io">bar</a></strong></div>')
+        })
+      })
     })
 
   })

--- a/src/range-save-restore.js
+++ b/src/range-save-restore.js
@@ -19,13 +19,11 @@ function isChildOf (parent, possibleChild) {
 }
 
 function isChildAtBeginning (parent, possibleChild) {
-  const isChild = isChildOf(parent, possibleChild)
-  return isChild && parent.childNodes[0] === possibleChild
+  return isChildOf(parent, possibleChild)
 }
 
 function isChildAtEnd (parent, possibleChild) {
-  const isChild = isChildOf(parent, possibleChild)
-  return isChild && parent.childNodes[parent.children.length - 1] === possibleChild
+  return isChildOf(parent, possibleChild)
 }
 
 export function insertRangeBoundaryMarker (range, atStart) {
@@ -55,9 +53,10 @@ export function insertRangeBoundaryMarker (range, atStart) {
   // if another tag is trailing exactly at the start or end, prepend
   // or append the marker element directly on the parent.
   if (trailsStart && atStart) {
-    range.endContainer.parentElement.prepend(markerEl)
+    range.endContainer.parentElement.insertBefore(markerEl, range.startContainer.parentElement)
   } else if (trailsEnd && !atStart) {
-    range.startContainer.parentElement.append(markerEl)
+    // emulating insertAfter with nextSibling
+    range.startContainer.parentElement.insertBefore(markerEl, range.endContainer.parentElement.nextSibling)
   } else {
     // Clone the Range and collapse to the appropriate boundary point
     const boundaryRange = range.cloneRange()


### PR DESCRIPTION
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4333

## Motivation

A link is removed when a bold tag is created around. It happens only when bold surrounds more than the link.

![editablewithlink](https://user-images.githubusercontent.com/4352425/117456214-3ebcd180-af48-11eb-8a1d-9b01a76db757.gif)

The problem is actually more general. Whenever a formatting tag is selected directly at the beginning (leading) or end (trailing) the marker will be set *inside* of the format tag thus destroying the HTML markup.

## Changelog

### :beetle: Check format tag position over range

We use the selection range of the browser to check if the selection is directly leading or trailing a formatting tag. If so, we manually set the marker tag directly before or after the format tag in order to keep the HTML markup intact.


## Testing

Manually tested on:
- Mac OSX Chrome
- Mac OSX Safari
- Mac OSX Firefox
- Windows 11 Edge