### PR TITLE
introduce trim config for formats

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -359,6 +359,55 @@ describe('Selection', function () {
 
   })
 
+  describe('triming:', function () {
+    beforeEach(function () {
+      this.wordWithWhitespace = createElement('<div> foobar </div>')
+      const range = rangy.createRange()
+      range.selectNodeContents(this.wordWithWhitespace.firstChild)
+      this.selection = new Selection(this.wordWithWhitespace, range)
+
+      this.oldLinkMarkup = config.italicMarkup
+      config.linkMarkup = {
+        type: 'tag',
+        name: 'a',
+        attribs: {
+          'class': 'foo bar'
+        },
+        trim: true
+      }
+
+      this.oldUnderlineMarkup = config.underlineMarkup
+      config.underlineMarkup = {
+        type: 'tag',
+        name: 'u',
+        attribs: {
+          'class': 'bar'
+        },
+        trim: false
+      }
+    })
+
+    afterEach(function () {
+      config.linkMarkup = this.oldLinkMarkup
+      config.underlineMarkup = this.oldUnderlineMarkup
+    })
+
+    it('trims whitespaces from range when linking', function () {
+      this.selection.link('https://livingdocs.io')
+      console.log('tag', this.wordWithWhitespace)
+      const linkTags = this.selection.getTagsByName('a')
+      const html = getHtml(linkTags[0])
+      expect(html).to.equal('<a class="foo bar" href="https://livingdocs.io">foobar</a>')
+    })
+
+    it('does not trim whitespaces from range when underlining', function () {
+      this.selection.makeUnderline()
+      const underlineTags = this.selection.getTagsByName('u')
+      const html = getHtml(underlineTags[0])
+      expect(html).to.equal('<u class="bar"> foobar </u>')
+    })
+  })
+
   describe('inherits form Cursor', function () {
 
     it('has isAtEnd() method from Cursor in its protoype chain', function () {

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -406,6 +406,17 @@ describe('Selection', function () {
       const html = getHtml(underlineTags[0])
       expect(html).to.equal('<u class="bar"> foobar </u>')
     })
+
+    it('trims a range with special whitespaces', function () {
+      // at the beginning we have U+2002, U+2005 and U+2006 in the end a normal whitespace
+      const wordWithSpecialWhitespaces = createElement('<div>   bar </div>')
+      const range = rangy.createRange()
+      range.selectNodeContents(wordWithSpecialWhitespaces.firstChild)
+      const selection = new Selection(wordWithSpecialWhitespaces, range)
+      selection.trimRange()
+      expect(selection.range.startOffset).to.equal(3)
+      expect(selection.range.endOffset).to.equal(6)
+    })
   })
 
   describe('inherits form Cursor', function () {

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -394,7 +394,6 @@ describe('Selection', function () {
 
     it('trims whitespaces from range when linking', function () {
       this.selection.link('https://livingdocs.io')
-      console.log('tag', this.wordWithWhitespace)
       const linkTags = this.selection.getTagsByName('a')
       const html = getHtml(linkTags[0])
       expect(html).to.equal('<a class="foo bar" href="https://livingdocs.io">foobar</a>')
@@ -416,6 +415,22 @@ describe('Selection', function () {
       selection.trimRange()
       expect(selection.range.startOffset).to.equal(3)
       expect(selection.range.endOffset).to.equal(6)
+    })
+
+    it('does trim if only a whitespace is selected', function () {
+      const whitespaceOnly = createElement('<div> </div>')
+      const range = rangy.createRange()
+      range.selectNodeContents(whitespaceOnly.firstChild)
+      const selection = new Selection(whitespaceOnly, range)
+      selection.trimRange()
+      expect(selection.toString()).to.equal('')
+    })
+
+    it('trims a custom element if the param is given', function () {
+      this.selection.toggleCustom({tagName: 'span', attributes: {class: 'foo'}, trim: true})
+      const spanTags = this.selection.getTagsByName('span')
+      const html = getHtml(spanTags[0])
+      expect(html).to.equal('<span class="foo">foobar</span>')
     })
   })
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,22 +13,26 @@ export default {
   boldMarkup: {
     type: 'tag',
     name: 'strong',
-    attribs: {}
+    attribs: {},
+    trim: true
   },
   italicMarkup: {
     type: 'tag',
     name: 'em',
-    attribs: {}
+    attribs: {},
+    trim: true
   },
   underlineMarkup: {
     type: 'tag',
     name: 'u',
-    attribs: {}
+    attribs: {},
+    trim: false
   },
   linkMarkup: {
     type: 'tag',
     name: 'a',
-    attribs: {}
+    attribs: {},
+    trim: true
   },
 
   // Rules that are applied when filtering pasted content

--- a/src/selection.js
+++ b/src/selection.js
@@ -87,7 +87,18 @@ export default class Selection extends Cursor {
         link.setAttribute(key, value)
       }
     }
+    if (config.linkMarkup.trim) this.trimRangeWhitespaces()
+
     this.forceWrap(link)
+  }
+
+  // trims whitespaces on the left and right of a selection, i.e. what you want in case of links
+  trimRangeWhitespaces () {
+    const textToLink = this.range.toString()
+    const whitespacesOnTheLeft = textToLink.search(/\S|$/)
+    const whitespacesOnTheRight = textToLink.length - whitespacesOnTheLeft - textToLink.trim().length
+    this.range.setStart(this.range.startContainer, this.range.startOffset + whitespacesOnTheLeft)
+    this.range.setEnd(this.range.endContainer, this.range.endOffset - whitespacesOnTheRight)
   }
 
   unlink () {
@@ -149,31 +160,37 @@ export default class Selection extends Cursor {
 
   makeBold () {
     const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
+    if (config.boldMarkup.trim) this.trimRangeWhitespaces()
     this.forceWrap(bold)
   }
 
   toggleBold () {
     const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
+    if (config.boldMarkup.trim) this.trimRangeWhitespaces()
     this.toggle(bold)
   }
 
   giveEmphasis () {
     const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
+    if (config.italicMarkup.trim) this.trimRangeWhitespaces()
     this.forceWrap(em)
   }
 
   toggleEmphasis () {
     const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
+    if (config.italicMarkup.trim) this.trimRangeWhitespaces()
     this.toggle(em)
   }
 
   makeUnderline () {
     const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
+    if (config.underlineMarkup.trim) this.trimRangeWhitespaces()
     this.forceWrap(u)
   }
 
   toggleUnderline () {
     const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
+    if (config.underlineMarkup.trim) this.trimRangeWhitespaces()
     this.toggle(u)
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -87,16 +87,17 @@ export default class Selection extends Cursor {
         link.setAttribute(key, value)
       }
     }
-    if (config.linkMarkup.trim) this.trimRangeWhitespaces()
+    if (config.linkMarkup.trim) this.trimRange()
 
     this.forceWrap(link)
   }
 
   // trims whitespaces on the left and right of a selection, i.e. what you want in case of links
-  trimRangeWhitespaces () {
+  trimRange () {
     const textToLink = this.range.toString()
     const whitespacesOnTheLeft = textToLink.search(/\S|$/)
-    const whitespacesOnTheRight = textToLink.length - whitespacesOnTheLeft - textToLink.trim().length
+    const lastNonWhitespace = textToLink.search(/\S[\s]+$/)
+    const whitespacesOnTheRight = lastNonWhitespace === -1 ? 0 : textToLink.length - (lastNonWhitespace + 1)
     this.range.setStart(this.range.startContainer, this.range.startOffset + whitespacesOnTheLeft)
     this.range.setEnd(this.range.endContainer, this.range.endOffset - whitespacesOnTheRight)
   }
@@ -160,37 +161,37 @@ export default class Selection extends Cursor {
 
   makeBold () {
     const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
-    if (config.boldMarkup.trim) this.trimRangeWhitespaces()
+    if (config.boldMarkup.trim) this.trimRange()
     this.forceWrap(bold)
   }
 
   toggleBold () {
     const bold = this.createElement(config.boldMarkup.name, config.boldMarkup.attribs)
-    if (config.boldMarkup.trim) this.trimRangeWhitespaces()
+    if (config.boldMarkup.trim) this.trimRange()
     this.toggle(bold)
   }
 
   giveEmphasis () {
     const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
-    if (config.italicMarkup.trim) this.trimRangeWhitespaces()
+    if (config.italicMarkup.trim) this.trimRange()
     this.forceWrap(em)
   }
 
   toggleEmphasis () {
     const em = this.createElement(config.italicMarkup.name, config.italicMarkup.attribs)
-    if (config.italicMarkup.trim) this.trimRangeWhitespaces()
+    if (config.italicMarkup.trim) this.trimRange()
     this.toggle(em)
   }
 
   makeUnderline () {
     const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
-    if (config.underlineMarkup.trim) this.trimRangeWhitespaces()
+    if (config.underlineMarkup.trim) this.trimRange()
     this.forceWrap(u)
   }
 
   toggleUnderline () {
     const u = this.createElement(config.underlineMarkup.name, config.underlineMarkup.attribs)
-    if (config.underlineMarkup.trim) this.trimRangeWhitespaces()
+    if (config.underlineMarkup.trim) this.trimRange()
     this.toggle(u)
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -149,13 +149,15 @@ export default class Selection extends Cursor {
     this.setSelection()
   }
 
-  toggleCustom ({tagName, attributes}) {
+  toggleCustom ({tagName, attributes, trim = false}) {
     const customElem = this.createElement(tagName, attributes)
+    if (trim) this.trimRange()
     this.toggle(customElem)
   }
 
-  makeCustom ({tagName, attributes}) {
+  makeCustom ({tagName, attributes, trim = false}) {
     const customElem = this.createElement(tagName, attributes)
+    if (trim) this.trimRange()
     this.forceWrap(customElem)
   }
 


### PR DESCRIPTION
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4538

## Motivation

So far editable.js made no special handling for leading or trailing whitespaces in a selection. While in general, it is smart to not make too many assumptions for some formats leading or trailing whitespaces make very little sense. The initial case of this issue was that links leave an empty `<a>` tag with a whitespace if the "visible" part of the link is deleted. While it would be possible to use the `del` and `backspace` event to clean up such cases after every delete IMO this is the wrong way to see this.
There are formats for which leading and trailing whitespaces make no sense. For this reason we introduce a `trim` config to the standard formats that if  set to `true` will not consider leading or trailing whitespaces in the first place. In the example of a link the following selection ` foo bar ` would trim and produce `<a href="..">foo bar</a>`.
There are also formats for which the case is not so clear. For example an underline is visible and at least the case could be made that we want to underline leading and trailing whitespaces. For our custom tags such as "Viertelgefiert", etc. it is explicitly wanted to wrap whitespaces.

## Changelog

### 🎁  Introduce `trim` config on standard formats

We introduce a config `trim` on the standard formats. On the link this would look as follows:
```
linkMarkup: {
    type: 'tag',
    name: 'a',
    attribs: {},
    trim: true
  }
```

If `trim` is set to true then the selection is trimmed before the format is applied. For example setting a link on ` foo bar ` would produce `<a href="..">foo bar</a>`.
The default setting is to set `trim` to `true` for `bold`, `italic`, `link` and false for `underline`. We don't introduce this property for custom tags as this seems too dangerous.

## Testing

Manually tested on:

- Mac OSX Chrome
- Mac OSX Safari
- Mac OSX Firefox
- Windows 11 Edge