### PR TITLE
Pass native range with getHighlightPositions

### DIFF
--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -117,7 +117,8 @@ const highlightSupport = {
     return {
       start: textRange.start,
       end: textRange.end,
-      text: range.text()
+      text: range.text(),
+      nativeRange: range.nativeRange
     }
   },
 


### PR DESCRIPTION
## Changelog

### 🎁  Pass the native range along with the `getHighlightPositions` method

Previously, the `getHighlightPositions` only returned the highlighted text as well as the text positions (not node positions!) of the range. This is handy if one wants to work with the text but not so much if the handling is with the selection itself. E.g. one might want to cut from the span nodes around the highlight which is not possible given only the text offsets.
We now also return the native range that represents the hightlight so users can freely choose how to interact with it.