### PR TITLE
Fix bug in save and restore

### DIFF
--- a/src/range-save-restore.js
+++ b/src/range-save-restore.js
@@ -19,13 +19,15 @@ function isChildOf (parent, possibleChild) {
 }
 
 function startContainerIsChild (range) {
-  const parent = range.endContainer.parentElement
+  const parent = range.commonAncestorContainer
+  if (parent.nodeType === 3) return false // if we are on the text node it can't be a parent
   const possibleChild = range.startContainer.parentElement
   return isChildOf(parent, possibleChild)
 }
 
 function endContainerIsChild (range) {
-  const parent = range.startContainer.parentElement
+  const parent = range.commonAncestorContainer
+  if (parent.nodeType === 3) return false // if we are on the text node it can't be a parent
   const possibleChild = range.endContainer.parentElement
   return isChildOf(parent, possibleChild)
 }


### PR DESCRIPTION
## Changelog

### 🐞 Save and restore set wrong markers

With the fix for formats over links (https://github.com/livingdocsIO/editable.js/pull/251) we introduced a bug that markers could be set outside of the host. 
The problem was that we used `parentElement` in order to get the ranges parent instead of `commonAncestorContainer` which will always contain the resulting element to the host that contains the selection.