### PR TITLE
fix: replace <br> elements with '\n' instead of one space

### DIFF
--- a/spec/highlight-text.spec.js
+++ b/spec/highlight-text.spec.js
@@ -92,7 +92,7 @@ describe('highlightText', function () {
     it('extracts text with a <br> properly', function () {
       this.element = createElement('<div>a<br>b</div>')
       const text = highlightText.extractText(this.element)
-      expect(text).to.equal('a b')
+      expect(text).to.equal('a\nb')
     })
   })
 

--- a/src/highlight-text.js
+++ b/src/highlight-text.js
@@ -134,7 +134,7 @@ export default {
 // This has two notable behaviours:
 // - It uses a NodeIterator which will skip elements
 //   with data-editable="remove"
-// - It returns a space for <br> elements
+// - It returns a \n for <br> elements
 //   (The only block level element allowed inside of editables)
 function getText (element, callback) {
   const iterator = new NodeIterator(element)
@@ -143,7 +143,7 @@ function getText (element, callback) {
     if (next.nodeType === nodeType.textNode && next.data !== '') {
       callback(next.data)
     } else if (next.nodeType === nodeType.elementNode && next.nodeName === 'BR') {
-      callback(' ')
+      callback('\n')
     }
   }
 }


### PR DESCRIPTION
Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4573


# Changelog

- 🐞 Fix highlighting of paragraphs with soft breaks in the multi-paragraph selection.

On the [getText()](https://github.com/livingdocsIO/editable.js/blob/e3a62f9db98eec94af392a6115fa490ac4281a5f/src/highlight-text.js#L139), which is used only in [extractText()](https://github.com/livingdocsIO/editable.js/blob/e3a62f9db98eec94af392a6115fa490ac4281a5f/src/highlight-text.js#L11), replace `<br>` with `\n` instead of an empty space.
This way in the in the [highlightText()](https://github.com/livingdocsIO/editable.js/blob/e3a62f9db98eec94af392a6115fa490ac4281a5f/src/highlight-support.js#L22), the `blockText` that comes from `extractText()` will have matches with the `text` argument that also treats `<br>`'s as `\n`'s.



