### PR TITLE
fix: replace &nbsp; with normal space on 'paste' event

### DIFF
--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -379,6 +379,33 @@ describe('Dispatcher', function () {
         const evt = new ClipboardEvent('paste', {clipboardData, bubbles: true})
         elem.dispatchEvent(evt)
       })
+
+      it(`replaces the last '&nbsp' with ' ' if text ends with a single '&nbsp'`, (done) => {
+        on('paste', (block, blocks) => {
+          expect(block.innerHTML).to
+            .equal('some text that ends with a single a non breaking space ')
+          done()
+        })
+        elem.innerHTML = 'some text that ends with a single a non breaking space&nbsp;'
+        const clipboardData = new DataTransfer()
+        clipboardData.setData('text/html', 'copied text')
+        const evt = new ClipboardEvent('paste', {clipboardData, bubbles: true})
+        elem.dispatchEvent(evt)
+      })
+
+      it(`doesn't replaces the last '&nbsp' with ' ' if text ends with more than one '&nbsp'`,
+        (done) => {
+          on('paste', (block, blocks) => {
+            expect(block.innerHTML).to
+              .equal('some text that ends with more than one non breaking space&nbsp; &nbsp;')
+            done()
+          })
+          elem.innerHTML = 'some text that ends with more than one non breaking space&nbsp; &nbsp;'
+          const clipboardData = new DataTransfer()
+          clipboardData.setData('text/html', 'copied text')
+          const evt = new ClipboardEvent('paste', {clipboardData, bubbles: true})
+          elem.dispatchEvent(evt)
+        })
     })
   })
 })

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -5,6 +5,7 @@ import SelectionWatcher from './selection-watcher'
 import config from './config'
 import Keyboard from './keyboard'
 import {closest} from './util/dom'
+import {replaceLast, endsWithSingleSpace} from './util/string'
 
 // This will be set to true once we detect the input event is working.
 // Input event description on MDN:
@@ -134,7 +135,12 @@ export default class Dispatcher {
 
         const {blocks, cursor} = clipboard.paste(block, selection, clipboardContent)
         if (blocks.length) {
-          this.notify('paste', block, blocks, cursor)
+          if (endsWithSingleSpace(evt.target.innerText)) {
+            block.innerHTML = replaceLast(block.innerHTML, '&nbsp;', ' ')
+            this.notify('paste', block, blocks, this.editable.createCursorAtEnd(block))
+          } else {
+            this.notify('paste', block, blocks, cursor)
+          }
 
           // The input event does not fire when we process the content manually
           // and insert it via script

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -61,3 +61,21 @@ export function browserEscapeHtml (str) {
   div.appendChild(document.createTextNode(str))
   return div.innerHTML
 }
+
+export function replaceLast (text, searchValue, replaceValue) {
+  if (!text) return ''
+  text = `${text}`
+  if (!searchValue || replaceValue == null) return text
+  const lastOccurrenceIndex = text.lastIndexOf(searchValue)
+  return `${
+    text.slice(0, lastOccurrenceIndex)
+  }${
+    replaceValue
+  }${
+    text.slice(lastOccurrenceIndex + searchValue.length)
+  }`
+}
+
+export function endsWithSingleSpace (text) {
+  return /\S+\s{1}$/.test(text)
+}


### PR DESCRIPTION
Relations:

- Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4587


# Motivation

If on an editable you add a space and then paste some text, the space added previously will be converted on a `non breaking space`.


# Changelog

- 🐞 Replace `non breaking spaces` with normal spaces when pasting on an `editable`.


