### PR TITLE
feat: add 'trimLeadingAndTrailingWhitespaces' config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ export default {
   editableClass: 'js-editable',
   editableDisabledClass: 'js-editable-disabled',
   pastingAttribute: 'data-editable-is-pasting',
+  trimLeadingAndTrailingWhitespaces: true,
   boldMarkup: {
     type: 'tag',
     name: 'strong',

--- a/src/content.js
+++ b/src/content.js
@@ -4,6 +4,7 @@ import * as rangeSaveRestore from './range-save-restore'
 import * as parser from './parser'
 import * as string from './util/string'
 import {createElement} from './util/dom'
+import config from './config'
 
 function restoreRange (host, range, func) {
   range = rangeSaveRestore.save(range)
@@ -161,7 +162,9 @@ function removeWhitespaces (node, type, firstCall = true) {
   if (elem?.nodeType !== nodeType.textNode) return
   // Remove whitespaces at the end or start of a block with content
   //   e.g. '  Hello world' > 'Hello World'
-  elem.textContent = elem.textContent.replace(type.startsWith('last') ? /\s+$/ : /^\s+/, '')
+  if (config.trimLeadingAndTrailingWhitespaces) {
+    elem.textContent = elem.textContent.replace(type.startsWith('last') ? / +$/ : /^ +/, '')
+  }
 }
 
 // Remove elements that were inserted for internal or user interface purposes


### PR DESCRIPTION
Relations:
  - Related PR's:
    - https://github.com/livingdocsIO/editable.js/pull/246#issuecomment-1061169814


# Motivation

Some customers want to disable the feature that removes the leading and trailing spaces from and editable.


# Changelog

- 🎁  New config `trimLeadingAndTrailingWhitespaces`. With it we can configure if we want to remove or not the leading and trailing spaces from and editable.


