### PR TITLE
fix(comment index): index is found with search in added case

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -400,7 +400,7 @@ export class Editable {
       )
       return -1
     }
-    return highlightSupport.highlightRange(editableHost, highlightId, textRange.start, textRange.end, raiseEvents ? this.dispatcher : undefined, type)
+    return highlightSupport.highlightRange(editableHost, text, highlightId, textRange.start, textRange.end, raiseEvents ? this.dispatcher : undefined, type)
   }
 
   /**


### PR DESCRIPTION
Relations:
  - Issue: If a word was repeated in a component all copies of that word were highlighted. Furthermore, if a comment was added and then text was added to the component before the highlighted comment the highlight moved

  - Related PR's: [Editor PR](https://github.com/livingdocsIO/livingdocs-editor/pull/5153)


# Motivation

NZZ reported the case where the same word in a component was highlighted repeatedly when an article was re-oponed after highlighting and resolving. When investigating this, it turned out there were several bugs related to the saving of the start index of the comments. This PR combined with the above Editor PR aims to fix this. 

So the use cases where this bug happens is as follows:

- A user comments on a word and resolves the comment
- A user reopens the article or refreshes the page, and reopens the comment
- If there are more than one version of that word in the component then all of them are highlighted


- Alternatively, a comment is highlighted and resolved, the component is altered to have more text added, and then the comment is resolved
- This will change the position of the highlihgt. 
- . 

Multiple word bug:
https://user-images.githubusercontent.com/76001984/160699422-bda46ae7-7e1f-42cf-9d7a-58e23ac88f0b.mov

Behaviour now:

https://user-images.githubusercontent.com/76001984/160699614-acff6ec6-a637-4036-8cc8-4e962d3beab4.mov

The limit to this fix is, if the word is repeated many times in close succession and one is commented, and text is added before the word, and then the comment is resolved, the page refreshed or the article re-entered (a rather rare edge case), then the comment will be highlighted on a different copy of the word.

# Changelog


- 🐞 Multiples of a highlighted word are not highlighted when comment is added and resolved after refresh
