### PR TITLE
fix(cutandpaste): Cursor not moved

### DIFF
--- a/spec/dispatcher.spec.js
+++ b/spec/dispatcher.spec.js
@@ -383,7 +383,9 @@ describe('Dispatcher', function () {
       it(`replaces the last '&nbsp' with ' ' if text ends with a single '&nbsp'`, (done) => {
         on('paste', (block, blocks) => {
           expect(block.innerHTML).to
-            .equal('some text that ends with a single a non breaking space ')
+            .equal('some text that ends with a single a non breaking space ') // space has been removed
+          expect(blocks.length).to.equal(1)
+          expect(blocks[0]).to.equal('copied text') // copied text is still in the paste event
           done()
         })
         elem.innerHTML = 'some text that ends with a single a non breaking space&nbsp;'

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -136,12 +136,11 @@ export default class Dispatcher {
         const {blocks, cursor} = clipboard.paste(block, selection, clipboardContent)
         if (blocks.length) {
           if (endsWithSingleSpace(evt.target.innerText)) {
-            block.innerHTML = replaceLast(block.innerHTML, '&nbsp;', ' ')
-            this.notify('paste', block, blocks, this.editable.createCursorAtEnd(block))
-          } else {
-            this.notify('paste', block, blocks, cursor)
+            cursor.retainVisibleSelection(() => {
+              block.innerHTML = replaceLast(block.innerHTML, '&nbsp;', ' ')
+            })
           }
-
+          this.notify('paste', block, blocks, cursor)
           // The input event does not fire when we process the content manually
           // and insert it via script
           this.notify('change', block)

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -67,6 +67,7 @@ export function replaceLast (text, searchValue, replaceValue) {
   text = `${text}`
   if (!searchValue || replaceValue == null) return text
   const lastOccurrenceIndex = text.lastIndexOf(searchValue)
+  if (lastOccurrenceIndex === -1) return text
   return `${
     text.slice(0, lastOccurrenceIndex)
   }${


### PR DESCRIPTION
Relations:

Backport: release-2022-05 and release 2022-03
Issue: When anything was pasted into an editable with a space at the end it was pasted at the end of the component
Documentation: -
Related PR's: https://github.com/livingdocsIO/editable.js/pull/266


Motivation

NZZ noticed that when an editor cut from the end of a component and pasted it, sometimes it was pasted back to where it was cut from. This was an unexpected side effect of Muhamet's fix to remove the non breaking space at the end of editables. 


https://user-images.githubusercontent.com/76001984/173227449-178d9247-792c-4b38-b986-51349b933227.mov

Furthermore, Sternwald reported that for some users when using shift + enter properties were added to <br> tags. This is fixed with the updated check in `utils/string.js`. 

The test is a bit superfluous, but checks that the NBSP is removed and that the copied text still exists in the event.

Changelog
🐞 Pasting text into components with a space at the end works correctly and no properties are added to new lines


Cheat Sheet: https://github.com/livingdocsIO/team/blob/master/Coding/Collaboration/Pull-Request-Cheatsheet.md