### PR TITLE
fix: pasting text over selected text which contains markups

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -78,6 +78,31 @@ describe('Selection', function () {
     })
   })
 
+  describe('deleteExactSurroundingTags:', function () {
+    it('deletes the farest ancestor that exactly surrounds the selection', function () {
+      const content = createElement('<p>text <strong><em>italic</em></strong> text</p>')
+      const em = content.getElementsByTagName('em')[0]
+      const range = rangy.createRange()
+      range.setStart(em, 0)
+      range.setEnd(em, 1)
+      let selection = new Selection(content, range)
+      selection = selection.deleteExactSurroundingTags()
+      expect(selection.host.innerHTML).to.equal('text  text')
+    })
+  })
+
+  describe('deleteContainedTags:', function () {
+    it('deletes all the tags whose content is completely within the current selection: ', function () {
+      const content = createElement('<p>text <strong>bold</strong> text')
+      const range = rangy.createRange()
+      range.setStart(content, 1)
+      range.setEnd(content, 3)
+      let selection = new Selection(content, range)
+      selection = selection.deleteContainedTags()
+      expect(selection.host.innerHTML).to.equal('text  text')
+    })
+  })
+
   describe('with a range', function () {
 
     beforeEach(function () {

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -30,8 +30,8 @@ export function paste (element, cursor, clipboardContent) {
   element.setAttribute(config.pastingAttribute, true)
 
   if (cursor.isSelection) {
-    cursor = cursor.deleteExactSurroundingMarkups()
-      .deleteContainedMarkupTags()
+    cursor = cursor.deleteExactSurroundingTags()
+      .deleteContainedTags()
       .deleteContent()
   }
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -29,7 +29,11 @@ export function paste (element, cursor, clipboardContent) {
   const document = element.ownerDocument
   element.setAttribute(config.pastingAttribute, true)
 
-  if (cursor.isSelection) cursor = cursor.deleteContent()
+  if (cursor.isSelection) {
+    cursor = cursor.deleteExactSurroundingMarkups()
+      .deleteContainedMarkupTags()
+      .deleteContent()
+  }
 
   // Create a placeholder to help parse HTML
   const pasteHolder = document.createElement('div')

--- a/src/content.js
+++ b/src/content.js
@@ -244,6 +244,12 @@ export function getInnerTags (range, filterFunc) {
   return range.getNodes([nodeType.elementNode], filterFunc)
 }
 
+// Get all tags whose text is completely within the current selection.
+export function getContainedTags (range, filterFunc) {
+  return range.getNodes([nodeType.elementNode], filterFunc)
+    .filter(elem => range.containsNodeText(elem))
+}
+
 // Transform an array of elements into an array
 // of tagnames in uppercase
 //

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -69,6 +69,11 @@ export default class Cursor {
     return content.getInnerTags(this.range, filterFunc)
   }
 
+  // Get all tags whose text is completely within the current selection.
+  getContainedTags (filterFunc) {
+    return content.getContainedTags(this.range, filterFunc)
+  }
+
   // Get all tags that surround the current selection.
   getAncestorTags (filterFunc) {
     return content.getAncestorTags(this.host, this.range, filterFunc)

--- a/src/selection.js
+++ b/src/selection.js
@@ -246,16 +246,30 @@ export default class Selection extends Cursor {
   }
 
   // Delete the farest ancestor that is an exact selection
+  //
+  // @return Selection instance
   deleteExactSurroundingMarkups () {
-    const markupTags = this.getAncestorTags(
+    const ancestorMarkupTags = this.getAncestorTags(
       (elem) => ['STRONG', 'EM'].includes(elem.nodeName)
     ).reverse()
-    for (const markupTag of markupTags) {
-      if (this.isExactSelection(markupTag)) {
-        markupTag.remove()
+    for (const ancestorMarkupTag of ancestorMarkupTags) {
+      if (this.isExactSelection(ancestorMarkupTag)) {
+        ancestorMarkupTag.remove()
         break
       }
     }
+    return new Selection(this.host, this.range)
+  }
+
+  // Delete all the markups whose text is completely within the current selection.
+  //
+  // @return Selection instance
+  deleteContainedMarkupTags () {
+    const containedMarkupTags = this.getContainedTags(
+      (elem) => ['STRONG', 'EM'].includes(elem.nodeName)
+    )
+    containedMarkupTags.forEach(containedMarkupTag => containedMarkupTag.remove())
+    return new Selection(this.host, this.range)
   }
 
   // Delete the contents inside the range and exact surrounding markups.
@@ -263,7 +277,6 @@ export default class Selection extends Cursor {
   //
   // @return Cursor instance
   deleteContent () {
-    this.deleteExactSurroundingMarkups()
     this.range.deleteContents()
     return new Cursor(this.host, this.range)
   }

--- a/src/selection.js
+++ b/src/selection.js
@@ -248,27 +248,23 @@ export default class Selection extends Cursor {
   // Delete the farest ancestor that is an exact selection
   //
   // @return Selection instance
-  deleteExactSurroundingMarkups () {
-    const ancestorMarkupTags = this.getAncestorTags(
-      (elem) => ['STRONG', 'EM'].includes(elem.nodeName)
-    ).reverse()
-    for (const ancestorMarkupTag of ancestorMarkupTags) {
-      if (this.isExactSelection(ancestorMarkupTag)) {
-        ancestorMarkupTag.remove()
+  deleteExactSurroundingTags () {
+    const ancestorTags = this.getAncestorTags().reverse()
+    for (const ancestorTag of ancestorTags) {
+      if (this.isExactSelection(ancestorTag)) {
+        ancestorTag.remove()
         break
       }
     }
     return new Selection(this.host, this.range)
   }
 
-  // Delete all the markups whose text is completely within the current selection.
+  // Delete all the tags whose text is completely within the current selection.
   //
   // @return Selection instance
-  deleteContainedMarkupTags () {
-    const containedMarkupTags = this.getContainedTags(
-      (elem) => ['STRONG', 'EM'].includes(elem.nodeName)
-    )
-    containedMarkupTags.forEach(containedMarkupTag => containedMarkupTag.remove())
+  deleteContainedTags () {
+    const containedTags = this.getContainedTags()
+    containedTags.forEach(containedTag => containedTag.remove())
     return new Selection(this.host, this.range)
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -245,11 +245,25 @@ export default class Selection extends Cursor {
     this.setSelection()
   }
 
-  // Delete the contents inside the range. After that the selection will be a
-  // cursor.
+  // Delete the farest ancestor that is an exact selection
+  deleteExactSurroundingMarkups () {
+    const markupTags = this.getAncestorTags(
+      (elem) => ['STRONG', 'EM'].includes(elem.nodeName)
+    ).reverse()
+    for (const markupTag of markupTags) {
+      if (this.isExactSelection(markupTag)) {
+        markupTag.remove()
+        break
+      }
+    }
+  }
+
+  // Delete the contents inside the range and exact surrounding markups.
+  // After that the selection will be a cursor.
   //
   // @return Cursor instance
   deleteContent () {
+    this.deleteExactSurroundingMarkups()
     this.range.deleteContents()
     return new Cursor(this.host, this.range)
   }


### PR DESCRIPTION
# Relations
  - Issue: https://tracking.nzzmg.ch/browse/WCMS-6398

# Description

There are two issues(videos below) related with pasting text over a selected text which contains markups like `<strong>` or `<em>`

https://user-images.githubusercontent.com/80449613/183460347-e33b442c-5426-472b-97bc-cef7f1b41c73.mov

https://user-images.githubusercontent.com/80449613/183459341-3d2662f3-4f37-487b-aca0-6ab11f48f473.mov


# Changelog

- 🐞 When we paste text while some other text is selected, check If the selected text is exactly surrounded by markup, and if yes delete that markup as well.
- 🐞 When we paste text while some other text is selected, check if there are markups whose text is completely within the current selection, and if yes delete that markup as well.