### PR TITLE
Prevent cursor loss on tab switch

### DIFF
--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -14,6 +14,7 @@ function setupHighlightEnv (context, text) {
   if (context.editable) context.editable.unload()
   context.editable = new Editable()
   context.editable.add(context.div)
+  // eslint-disable-next-line no-shadow
   context.highlightRange = (text, highlightId, start, end, dispatcher, type) => {
     return highlightSupport.highlightRange(
       context.div,

--- a/src/create-default-behavior.js
+++ b/src/create-default-behavior.js
@@ -35,6 +35,13 @@ export default function createDefaultBehavior (editable) {
     },
 
     blur (element) {
+      // Note: there is a special case when the tab is changed where
+      // we can get a blur event even if the cursor is still in the editable.
+      // This blur would cause us to loose the cursor position (cause of cleanInternals()).
+      // To prevent this we check if the activeElement is still the editable.
+      // (Note: document.getSelection() did not work reliably in this case.)
+      if (document.activeElement === element) return
+
       content.cleanInternals(element)
     },
 


### PR DESCRIPTION
Fixes: https://github.com/livingdocsIO/livingdocs-planning/issues/4773

## Changelog

- 🐞 Prevent cursor loss on tab switch
  
## Background

When switching tabs on coming back a blur event is raised on the editable.  After that the browser sets the cursor again. In our blur event we call `cleanInternals()` wich resets `innerHTML` which causes the browser to loose the cursor position and it sets the cursor to the beginning.
To prevent this we can use `document.activeElement` to check if the editable which receives the blur event is still the active element itself. If so we do an early abort and do not call `cleanInternals()`. 