### PR TITLE
fix: comment highlight when text is deleted

### DIFF
--- a/spec/highlighting.spec.js
+++ b/spec/highlighting.spec.js
@@ -382,6 +382,11 @@ ke The <br> World Go Round`)
       expect(highlightSpan.length).to.equal(0)
     })
 
+    it('does not throw when text has been deleted', function () {
+      setupHighlightEnv(this, '')
+      expect(() => this.highlightRange('not found', 'myId', 33, 38)).to.not.throw()
+    })
+
     it('normalizes a simple text node after removing a highlight', function () {
       setupHighlightEnv(this, 'People Make The World Go Round')
       this.highlightRange('ple ', 'myId', 3, 7)
@@ -670,7 +675,5 @@ Make The&nbsp;<br>&nbsp;W<span class="highlight-spellcheck" data-word-id="spellc
       expect(this.getHtml()).to.equal(expectedHtml)
       expect(this.extractWithoutNativeRange('comment')).to.deep.equal(expectedRanges)
     })
-
-
   })
 })

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -40,6 +40,7 @@ const highlightSupport = {
     const markerNode = highlightSupport.createMarkerNode(firstMarker, type, this.win)
     const textSearch = new TextHighlighting(markerNode, 'text')
     const blockText = highlightText.extractText(editableHost)
+    if (blockText === '') return -1 // the text was deleted so we can't highlight it
     const matchesArray = textSearch.findMatches(blockText, [text])
     const {actualStartIndex, actualEndIndex} = this.getIndex(matchesArray, startIndex, endIndex)
     const range = rangy.createRange()


### PR DESCRIPTION
## Changelog
🐞 Fix comment highlight when text comment was deleted
An issue was preventing the comments to be highlighted if the text of the comment was deleted. 
TextBlock is an empty string when the text was deleted, so there can't be any matches. 
The function returns immediately as there is no text to highlight in that case.