### PR TITLE
Support block-based plainText option

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -58,6 +58,26 @@
       </div>
     </section>
 
+    <!-- Plain Text -->
+    <section class="example-section space-after">
+      <div class="section-content">
+        <h2 class="example-title">Plain Text</h2>
+
+        <div class="plain-text-example example-sheet">
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero.</p>
+        </div>
+
+        <div class="code-example">
+          <p>Plain text blocks don't allow any markup. Newlines are replaced with spaces.</p>
+          <h3>Example:</h3>
+          <pre><code class="language-javascript">
+editable.add('.example', {plainText: true})
+          </code></pre>
+        </div>
+
+      </div>
+    </section>
+
 
     <!-- Styling -->
     <section class="example-section space-after">

--- a/examples/index.js
+++ b/examples/index.js
@@ -8,14 +8,17 @@ const editable = new Editable({browserSpellcheck: false})
 
 // Paragraph
 // ---------
-editable.enable('.paragraph-example p', true)
+editable.enable('.paragraph-example p', {normalize: true})
 eventList(editable)
 
 // Text formatting toolbar
-editable.enable('.formatting-example p', true)
+editable.enable('.formatting-example p', {normalize: true})
 setupTooltip()
 
-editable.enable('.styling-example p', true)
+// Plain Text
+editable.enable('.plain-text-example.example-sheet', {plainText: true})
+
+editable.enable('.styling-example p', {normalize: true})
 const secondExample = document.querySelector('.formatting-example p')
 updateCode(secondExample)
 

--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -17,6 +17,12 @@ describe('Clipboard', function () {
       return parseContent(div)
     }
 
+    function extractPlainText (str) {
+      const div = document.createElement('div')
+      div.innerHTML = str
+      return parseContent(div, {plainText: true})
+    }
+
     function extractSingleBlock (str) {
       return extract(str)[0]
     }
@@ -375,6 +381,43 @@ describe('Clipboard', function () {
       it('replaces quotation marks around elements with attributes', function () {
         const block = extractSingleBlock('text outside "<a href="https://livingdocs.io">text inside</a>"')
         expect(block).to.equal('text outside “<a href="https://livingdocs.io">text inside</a>”')
+      })
+    })
+
+    // Plain Text
+    // ----------
+
+    describe('plain text option', function () {
+      it('unwraps a single <b>', function () {
+        expect(extractPlainText('<b>a</b>')[0]).to.equal('a')
+      })
+
+      it('unwraps a single <strong>', function () {
+        expect(extractPlainText('<strong>a</strong>')[0]).to.equal('a')
+      })
+
+      it('unwraps nested <b><strong>', function () {
+        expect(extractPlainText('<b><strong>a</strong></b>')[0]).to.equal('a')
+      })
+
+      it('unwraps nested <span><strong>', function () {
+        expect(extractPlainText('<span><strong>a</strong></span>')[0]).to.equal('a')
+      })
+
+      it('keeps <br> tags', function () {
+        expect(extractPlainText('a<br>b')[0]).to.equal('a<br>b')
+      })
+
+      it('creates two blocks from two paragraphs', function () {
+        const blocks = extractPlainText('<p>a</p><p>b</p>')
+        expect(blocks[0]).to.equal('a')
+        expect(blocks[1]).to.equal('b')
+      })
+
+      it('unwraps phrasing tags within blocks', function () {
+        const blocks = extractPlainText('<p><i>a</i></p><p><em>b</em></p>')
+        expect(blocks[0]).to.equal('a')
+        expect(blocks[1]).to.equal('b')
       })
     })
   })

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import rangy from 'rangy'
 
+import {Editable} from '../src/core'
 import Selection from '../src/selection'
 import Cursor from '../src/cursor'
 import config from '../src/config'
@@ -465,6 +466,47 @@ describe('Selection', function () {
       expect(Selection.prototype.hasOwnProperty('isAtEnd')).to.equal(false)
       expect(Cursor.prototype.hasOwnProperty('isAtEnd')).to.equal(true)
       expect('isAtEnd' in Selection.prototype).to.equal(true)
+    })
+  })
+
+  describe('plain text host', function () {
+    beforeEach(function () {
+      this.editable = new Editable()
+    })
+
+    describe('with regular text', function () {
+      beforeEach(function () {
+        this.div = createElement('<div>regular text</div>')
+        const range = rangy.createRange()
+        range.selectNodeContents(this.div)
+        this.selection = new Selection(this.div, range)
+
+        this.editable.enable(this.div, {plainText: true})
+      })
+
+      it('should not make regular text bold on toggle', function () {
+        this.selection.toggleBold()
+        expect(this.div.innerHTML).to.equal('regular text')
+      })
+
+      it('should not make regular text bold on forceWrap', function () {
+        this.selection.makeBold()
+        expect(this.div.innerHTML).to.equal('regular text')
+      })
+
+      it('should not make regular text italic on toggle', function () {
+        this.selection.toggleEmphasis()
+        expect(this.div.innerHTML).to.equal('regular text')
+      })
+
+      it('should not make regular text italic on forceWrap', function () {
+        this.selection.giveEmphasis()
+        expect(this.div.innerHTML).to.equal('regular text')
+      })
+    })
+
+    afterEach(function () {
+      this.editable.disable(this.div)
     })
   })
 })

--- a/src/block.js
+++ b/src/block.js
@@ -7,11 +7,12 @@ const state = {}
 export const next = getSibling('nextElementSibling')
 export const previous = getSibling('previousElementSibling')
 
-export function init (elem, {normalize, shouldSpellcheck}) {
+export function init (elem, {normalize, plainText, shouldSpellcheck}) {
   setBlockId(elem)
 
   elem.setAttribute('contenteditable', true)
   elem.setAttribute('spellcheck', Boolean(shouldSpellcheck))
+  elem.setAttribute('data-plaintext', Boolean(plainText))
 
   elem.classList.remove(config.editableDisabledClass)
   elem.classList.add(config.editableClass)
@@ -23,6 +24,7 @@ export function init (elem, {normalize, shouldSpellcheck}) {
 export function disable (elem) {
   elem.removeAttribute('contenteditable')
   elem.removeAttribute('spellcheck')
+  elem.removeAttribute('data-plaintext')
 
   setState(elem, undefined)
 
@@ -30,6 +32,9 @@ export function disable (elem) {
   elem.classList.add(config.editableDisabledClass)
 }
 
+export function isPlainTextBlock (elem) {
+  return elem.getAttribute('data-plaintext') === 'true'
+}
 
 export function setBlockId (elem) {
   if (!elem.hasAttribute('data-editable')) {

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,9 @@ export default {
       'em': {},
       'br': {}
     },
+    allowedPlainTextElements: {
+      'br': {}
+    },
 
     // Elements that have required attributes.
     // If these are not present the elements are filtered out.

--- a/src/core.js
+++ b/src/core.js
@@ -93,10 +93,11 @@ export class Editable {
    * @param {HTMLElement|Array(HTMLElement)|String} target A HTMLElement, an
    *    array of HTMLElement or a query selector representing the target where
    *    the API should be added on.
+   * @param {normalize, plainText} options Block specific configuration
    * @chainable
    */
-  add (target) {
-    this.enable(target)
+  add (target, options) {
+    this.enable(target, options)
     // TODO check css whitespace settings
     return this
   }
@@ -143,19 +144,26 @@ export class Editable {
   }
 
   /**
-  * Adds the Editable.JS API to the given target elements.
-  *
-  * @method enable
-  * @param { HTMLElement | undefined } target editable root element(s)
-  *    If no param is specified all editables marked as disabled are enabled.
-  * @chainable
-  */
-  enable (target, normalize) {
+   * Adds the Editable.JS API to the given target elements.
+   *
+   * @method enable
+   * @param { HTMLElement | undefined } target editable root element(s)
+   *    If no param is specified all editables marked as disabled are enabled.
+   * @param {boolean} normalize normalizes target content (legacy param)
+   * @param {boolean} options.normalize normalizes target content
+   * @param {boolean} options.plainText prevents text formatting for block
+   * @chainable
+   */
+  enable (target, options) {
+    const {
+      normalize = typeof options === 'boolean' ? options : false,
+      plainText = false
+    } = options ?? {}
     const shouldSpellcheck = this.config.browserSpellcheck
     const targets = domArray(target || `.${config.editableDisabledClass}`, this.win.document)
 
     for (const element of targets) {
-      block.init(element, {normalize, shouldSpellcheck})
+      block.init(element, {normalize, plainText, shouldSpellcheck})
       this.dispatcher.notify('init', element)
     }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -3,6 +3,7 @@ import 'rangy/lib/rangy-textrange'
 import Cursor from './cursor'
 import * as content from './content'
 import * as parser from './parser'
+import * as block from './block'
 import config from './config'
 import highlightSupport from './highlight-support'
 import highlightText from './highlight-text'
@@ -144,6 +145,7 @@ export default class Selection extends Cursor {
 
   // toggle('<em>')
   toggle (elem) {
+    if (block.isPlainTextBlock(this.host)) return
     elem = this.adoptElement(elem)
     this.range = content.toggleTag(this.host, this.range, elem)
     this.setSelection()
@@ -307,6 +309,7 @@ export default class Selection extends Cursor {
   // the same tagName is affecting the selection this tag will be
   // remove first.
   forceWrap (elem) {
+    if (block.isPlainTextBlock(this.host)) return
     elem = this.adoptElement(elem)
     this.range = content.forceWrap(this.host, this.range, elem)
     this.setSelection()


### PR DESCRIPTION
Adds an option to configure plain text behavior per block.
- Commands like `toggleBold` won't work on selections within such a block
- Keyboard shortcuts for formatting won't work

To enable the behavior use:
`editable.add('.example', {plainText: true}` or `editable.enable('.example', {plainText: true}`

The normalize option can still be passed as second argument, or it can be included in the options parameter:
`editable.enable('.example', true)` or `editable.enable('.example', {normalize: true}`