### PR TITLE
Handle nodes and text when trimming whitespace from a selection

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -437,14 +437,16 @@ describe('Selection', function () {
     })
 
     it('trims a range with special whitespaces', function () {
-      // at the beginning we have U+2002, U+2005 and U+2006 in the end a normal whitespace
-      const wordWithSpecialWhitespaces = createElement('<div>   bar </div>')
+      // At the beginning we have U+2002, U+2005, U+2006, U+FEFF.
+      // At the end a normal whitespace.
+      // Note: U+200B is not handled by regular expression \s whitespace.
+      const wordWithSpecialWhitespaces = createElement('<div>   ﻿bar </div>')
       const range = createRange()
       range.selectNodeContents(wordWithSpecialWhitespaces.firstChild)
       const selection = new Selection(wordWithSpecialWhitespaces, range)
       selection.trimRange()
-      expect(selection.range.startOffset).to.equal(3)
-      expect(selection.range.endOffset).to.equal(6)
+      expect(selection.range.startOffset).to.equal(4)
+      expect(selection.range.endOffset).to.equal(7)
     })
 
     it('does trim if only a whitespace is selected', function () {
@@ -481,6 +483,25 @@ describe('Selection', function () {
       selection.makeBold()
       expect(selection.toString()).to.equal('')
       expect(this.wordWithWhitespace.innerHTML).to.equal(' foobar ')
+    })
+
+    it('handles nodes and characters', function () {
+      // Split word into three nodes: ` `, `foo`, `bar `
+      const range = createRange()
+      range.setStart(this.wordWithWhitespace.firstChild, 1)
+      range.setEnd(this.wordWithWhitespace.firstChild, 4)
+      const selection = new Selection(this.wordWithWhitespace, range)
+      selection.save()
+      selection.restore()
+
+      // Select specific characters within nodes across multiple nodes
+      const rangeTwo = createRange()
+      rangeTwo.setStart(this.wordWithWhitespace, 0) // Select first node (start)
+      rangeTwo.setEnd(this.wordWithWhitespace.childNodes[2], 2) // Select middle of last node
+      const selectionTwo = new Selection(this.wordWithWhitespace, rangeTwo)
+      selectionTwo.makeBold()
+
+      expect(this.wordWithWhitespace.innerHTML).to.equal(' <strong>fooba</strong>r ')
     })
   })
 

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -462,6 +462,26 @@ describe('Selection', function () {
       const html = getHtml(spanTags[0])
       expect(html).to.equal('<span class="foo">foobar</span>')
     })
+
+    it('does not apply tags to whitespace when toggling', function () {
+      const range = createRange()
+      range.setStart(this.wordWithWhitespace.firstChild, 0)
+      range.setEnd(this.wordWithWhitespace.firstChild, 1)
+      const selection = new Selection(this.wordWithWhitespace, range)
+      selection.toggleBold()
+      expect(selection.toString()).to.equal('')
+      expect(this.wordWithWhitespace.innerHTML).to.equal(' foobar ')
+    })
+
+    it('does not apply tags to whitespace when wrapping', function () {
+      const range = createRange()
+      range.setStart(this.wordWithWhitespace.firstChild, 0)
+      range.setEnd(this.wordWithWhitespace.firstChild, 1)
+      const selection = new Selection(this.wordWithWhitespace, range)
+      selection.makeBold()
+      expect(selection.toString()).to.equal('')
+      expect(this.wordWithWhitespace.innerHTML).to.equal(' foobar ')
+    })
   })
 
   describe('inherits form Cursor', function () {

--- a/src/selection.js
+++ b/src/selection.js
@@ -156,6 +156,7 @@ export default class Selection extends Cursor {
   // e.g. toggle('<em>')
   toggle (elem) {
     if (block.isPlainTextBlock(this.host)) return
+    if (this.range.collapsed) return
     elem = this.adoptElement(elem)
     this.range = content.toggleTag(this.host, this.range, elem)
     this.setVisibleSelection()
@@ -320,6 +321,7 @@ export default class Selection extends Cursor {
   // remove first.
   forceWrap (elem) {
     if (block.isPlainTextBlock(this.host)) return
+    if (this.range.collapsed) return
     elem = this.adoptElement(elem)
     this.range = content.forceWrap(this.host, this.range, elem)
     this.setVisibleSelection()

--- a/src/selection.js
+++ b/src/selection.js
@@ -5,7 +5,12 @@ import * as block from './block'
 import config from './config'
 import highlightSupport from './highlight-support'
 import highlightText from './highlight-text'
-import {toCharacterRange, rangeToHtml} from './util/dom'
+import {
+  toCharacterRange,
+  rangeToHtml,
+  findStartExcludingWhitespace,
+  findEndExcludingWhitespace
+} from './util/dom'
 
 /**
  * The Selection module provides a cross-browser abstraction layer for range
@@ -96,9 +101,25 @@ export default class Selection extends Cursor {
     const textToTrim = this.range.toString()
     const whitespacesOnTheLeft = textToTrim.search(/\S|$/)
     const lastNonWhitespace = textToTrim.search(/\S[\s]+$/)
-    const whitespacesOnTheRight = lastNonWhitespace === -1 ? 0 : textToTrim.length - (lastNonWhitespace + 1)
-    this.range.setStart(this.range.startContainer, this.range.startOffset + whitespacesOnTheLeft)
-    this.range.setEnd(this.range.endContainer, this.range.endOffset - whitespacesOnTheRight)
+    const whitespacesOnTheRight = lastNonWhitespace === -1
+      ? 0
+      : textToTrim.length - (lastNonWhitespace + 1)
+
+    const [startContainer, startOffset] = findStartExcludingWhitespace({
+      root: this.range.commonAncestorContainer,
+      startContainer: this.range.startContainer,
+      startOffset: this.range.startOffset,
+      whitespacesOnTheLeft
+    })
+    this.range.setStart(startContainer, startOffset)
+
+    const [endContainer, endOffset] = findEndExcludingWhitespace({
+      root: this.range.commonAncestorContainer,
+      endContainer: this.range.endContainer,
+      endOffset: this.range.endOffset,
+      whitespacesOnTheRight
+    })
+    this.range.setEnd(endContainer, endOffset)
   }
 
   unlink () {

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -1,3 +1,6 @@
+import NodeIterator from '../node-iterator'
+import {textNode} from '../node-type'
+
 /**
  * @param {HTMLElement | Array | String} target
  * @param {Document} document
@@ -228,8 +231,8 @@ export const createRangeFromCharacterRange = (element, actualStartIndex, actualE
   let startNode, endNode, startOffset, endOffset
 
   while (walker.nextNode()) {
-    const textNode = walker.currentNode
-    const nodeLength = textNode.nodeValue.length
+    const node = walker.currentNode
+    const nodeLength = node.nodeValue.length
 
     if (currentIndex + nodeLength <= actualStartIndex) {
       currentIndex += nodeLength
@@ -237,12 +240,12 @@ export const createRangeFromCharacterRange = (element, actualStartIndex, actualE
     }
 
     if (!startNode) {
-      startNode = textNode
+      startNode = node
       startOffset = actualStartIndex - currentIndex
     }
 
     if (currentIndex + nodeLength >= actualEndIndex) {
-      endNode = textNode
+      endNode = node
       endOffset = actualEndIndex - currentIndex
       break
     }
@@ -260,3 +263,87 @@ export const createRangeFromCharacterRange = (element, actualStartIndex, actualE
   }
 }
 
+export function findStartExcludingWhitespace ({root, startContainer, startOffset, whitespacesOnTheLeft}) {
+  const isTextNode = startContainer.nodeType === textNode
+  if (!isTextNode) {
+    return findStartExcludingWhitespace({
+      root,
+      startContainer: startContainer.childNodes[startOffset],
+      startOffset: 0,
+      whitespacesOnTheLeft
+    })
+  }
+
+  const offsetAfterWhitespace = startOffset + whitespacesOnTheLeft
+  if (startContainer.length > offsetAfterWhitespace) {
+    return [startContainer, offsetAfterWhitespace]
+  }
+
+  // Pass the root so that the iterator can traverse to siblings
+  const iterator = new NodeIterator(root)
+  // Set the position to the node which is selected
+  iterator.nextNode = startContainer
+  // Iterate once to avoid returning self
+  iterator.getNextTextNode()
+
+  const container = iterator.getNextTextNode()
+  if (!container) {
+    // No more text nodes - use the end of the last text node
+    const previousTextNode = iterator.getPreviousTextNode()
+    return [previousTextNode, previousTextNode.length]
+  }
+
+  return findStartExcludingWhitespace({
+    root,
+    startContainer: container,
+    startOffset: 0,
+    whitespacesOnTheLeft: offsetAfterWhitespace - startContainer.length
+  })
+}
+
+export function findEndExcludingWhitespace ({root, endContainer, endOffset, whitespacesOnTheRight}) {
+  const isTextNode = endContainer.nodeType === textNode
+  if (!isTextNode) {
+    const isFirstNode = !endContainer.childNodes[endOffset - 1]
+    const container = isFirstNode
+      ? endContainer.childNodes[endOffset]
+      : endContainer.childNodes[endOffset - 1]
+    let offset = 0
+    if (!isFirstNode) {
+      offset = container.nodeType === textNode
+        ? container.length
+        : container.childNodes.length
+    }
+    return findEndExcludingWhitespace({
+      root,
+      endContainer: container,
+      endOffset: offset,
+      whitespacesOnTheRight
+    })
+  }
+
+  const offsetBeforeWhitespace = endOffset - whitespacesOnTheRight
+  if (offsetBeforeWhitespace > 0) {
+    return [endContainer, offsetBeforeWhitespace]
+  }
+
+  // Pass the root so that the iterator can traverse to siblings
+  const iterator = new NodeIterator(root)
+  // Set the position to the node which is selected
+  iterator.previous = endContainer
+  // Iterate once to avoid returning self
+  iterator.getPreviousTextNode()
+
+  const container = iterator.getPreviousTextNode()
+  if (!container) {
+    // No more text nodes - use the start of the first text node
+    return [iterator.getNextTextNode(), 0]
+  }
+
+  return findEndExcludingWhitespace({
+    root,
+    endContainer: container,
+    endOffset: container.length,
+    whitespacesOnTheRight: whitespacesOnTheRight - endOffset
+  })
+}


### PR DESCRIPTION
Relations:
  - Issues:
    - Fixes https://github.com/livingdocsIO/livingdocs-bugs/issues/5083
    - Fixes https://github.com/livingdocsIO/livingdocs-bugs/issues/4895


# Motivation

We are trying to trim whitespace characters around selections for certain tags such as links, bold, italic etc. For links we add and remove span elements to save the range when the focus is lost, so we're actually dealing with text nodes for the offsets and not character offsets. For bold and italic it could be text node or character offsets that we're dealing with in the range. The code in master always assumes the offsets are characters.


# Changelog

- 🐞 Handle nodes and text when trimming whitespace from a selection
- 🐞 Don't wrap a collapsed selection with tags
