### PR TITLE
Use cloned Range in RangeContainer

### DIFF
--- a/src/range-container.js
+++ b/src/range-container.js
@@ -15,7 +15,10 @@ export default class RangeContainer {
     this.host = editableHost && editableHost.jquery
       ? editableHost[0]
       : editableHost
-    this.range = range
+    // Safari 17 seems to modify the range instance on the fly which breaks later comparisons.
+    // We clone the range at the time of the RangeContainer creation.
+    // https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#New-Features
+    this.range = range?.cloneRange()
     this.isAnythingSelected = (range !== undefined)
     this.isCursor = (this.isAnythingSelected && range.collapsed)
     this.isSelection = (this.isAnythingSelected && !this.isCursor)


### PR DESCRIPTION
Fixes https://github.com/livingdocsIO/livingdocs-bugs/issues/5153

Selection change events are only emitted if the selection range has changed. [Safari 17 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#New-Features) are talking about some "live ranges".

When double-clicking a word, first a collapsed range is handled followed by a second range which is no longer collapsed. In the `selectionWatcher.selectionChanged()`, we are only dispatching the event if the range changed. Since Safari seems to recycle the first range object, the comparision will never detect a change.

I fixed it by storing a cloned range object in the `RangeContainer`.