### PR TITLE
Fix whitespace trimming

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -626,6 +626,82 @@ describe('Content', function () {
       expect(result).to.equal('ac')
     })
 
+    describe('trim leading white space', function () {
+      it('removes single regular whitespace', function () {
+        const element = createElement('<div> hello world</div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('hello world')
+      })
+
+      it('removes multiple regular whitespaces', function () {
+        const element = createElement('<div>   hello world</div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('hello world')
+      })
+
+      it('removes &nbsp;', function () {
+        const element = createElement('<div>&nbsp; &nbsp;hello world</div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('hello world')
+      })
+
+      it('removes multiple regular whitespaces before tag', function () {
+        const element = createElement('<div>   <strong>hello world</strong></div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('<strong>hello world</strong>')
+      })
+
+      it('removes &nbsp; before tag', function () {
+        const element = createElement('<div>&nbsp;<strong>hello world</strong></div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('<strong>hello world</strong>')
+      })
+
+      it('keeps whitespace within tag', function () {
+        const element = createElement('<div>&nbsp;<strong> hello world</strong></div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('<strong> hello world</strong>')
+      })
+    })
+
+    describe('trim trailing white space', function () {
+      it('removes single regular whitespace', function () {
+        const element = createElement('<div>hello world </div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('hello world')
+      })
+
+      it('removes multiple regular whitespaces', function () {
+        const element = createElement('<div>hello world   </div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('hello world')
+      })
+
+      it('removes &nbsp;', function () {
+        const element = createElement('<div>hello world&nbsp; &nbsp;</div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('hello world')
+      })
+
+      it('removes multiple regular whitespaces after tag', function () {
+        const element = createElement('<div><strong>hello world</strong>   </div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('<strong>hello world</strong>')
+      })
+
+      it('removes &nbsp; after tag', function () {
+        const element = createElement('<div><strong>hello world</strong>&nbsp;</div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('<strong>hello world</strong>')
+      })
+
+      it('keeps whitespace within tag', function () {
+        const element = createElement('<div><strong>hello world </strong>&nbsp;</div>')
+        const result = content.extractContent(element)
+        expect(result).to.equal('<strong>hello world </strong>')
+      })
+    })
+
     describe('called with keepUiElements', function () {
 
       it('does not unwrap a "ui-unwrap" span', function () {


### PR DESCRIPTION
Relations:
 - Related PR's: https://github.com/livingdocsIO/editable.js/pull/267

# Changelog

- 🐞 Fixed a bug where extracted text content didn't trim `&nbsp;` characters

Another [PR](https://github.com/livingdocsIO/editable.js/pull/267) introduced the opt-out config `trimLeadingAndTrailingWhitespaces` to disable the trimming behavior. At the same time, it also changed the trimming logic to only remove the standard whitespace character(U+0200). As a result, other whitespace characters like `U+00A0` (Unicode for `&nbsp;`) were not removed.

Depending on the browser, such characters are inserted automatically when the space key is used at the start or end of a `contenteditable` element. Since this is very common, we decided to change the trimming back to the `\s` regex character class to match a wider variety of whitespace-kind characters.

## Required Actions
If this behavior is undesired, the config option `trimLeadingAndTrailingWhitespaces` needs to be set to `false`.