### PR TITLE
Fix clipboard copy pasting formatted text

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -125,7 +125,7 @@ function conditionalNodeWrap (child, content, options) {
 // returns string of concatenated attributes e.g. 'target="_blank" rel="nofollow" href="/test.com"'
 function filterAttributes (nodeName, node) {
   return Array.from(node.attributes).reduce((attributes, {name, value}) => {
-    if (allowedElements[nodeName][name] && value) {
+    if (allowedElements[nodeName]?.[name] && value) {
       return `${attributes} ${name}="${value}"`
     }
     return attributes


### PR DESCRIPTION
Relations:
- Issue: https://github.com/livingdocsIO/livingdocs-bugs/issues/5178

# Motivation

Copy pasting formatted text certain text/html throws an error. Although for me unclear how it can be `undefined` in the function as we check [one line before that it is not undefined](https://github.com/livingdocsIO/editable.js/blob/master/src/clipboard.js#L102) we can at least safely access it to not throw an error. 

# Changelog
- 🐛 Fix clipboard copy pasting formatted text throwing an error