### PR TITLE
Support toggling of partial, nested, and intersecting tags (Prototype)

### DIFF
--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -72,7 +72,9 @@ const highlightSupport = {
   removeHighlight (editableHost, highlightId, dispatcher) {
     const elems = editableHost.querySelectorAll(`[data-word-id="${highlightId}"]`)
     for (const elem of elems) {
-      content.unwrap(elem)
+      const range = document.createRange()
+      range.selectNode(elem)
+      content.unwrap(editableHost, range, elem)
     }
 
     // remove empty text nodes, combine adjacent text nodes

--- a/src/monitored-highlighting.js
+++ b/src/monitored-highlighting.js
@@ -138,6 +138,7 @@ export default class MonitoredHighlighting {
       matches = this.whitespace.findMatches(text)
       matchCollection.addMatches(matches)
 
+      // TODO: Fix: Do not expand range in some cases
       this.safeHighlightMatches(editableHost, matchCollection.matches)
     })
   }
@@ -172,7 +173,9 @@ export default class MonitoredHighlighting {
   removeHighlights (editableHost) {
     editableHost = domSelector(editableHost, this.win.document)
     for (const elem of domArray('[data-highlight="spellcheck"], [data-highlight="whitespace"]', editableHost)) {
-      content.unwrap(elem)
+      const range = document.createRange()
+      range.selectNode(elem)
+      content.unwrap(editableHost, range, elem)
     }
   }
 
@@ -198,7 +201,9 @@ export default class MonitoredHighlighting {
       if (wordId) {
         selection.retainVisibleSelection(() => {
           for (const elem of domArray(`[data-word-id="${wordId}"]`, editableHost)) {
-            content.unwrap(elem)
+            const range = document.createRange()
+            range.selectNode(elem)
+            content.unwrap(editableHost, range, elem)
           }
         })
       }


### PR DESCRIPTION
A prototype attempting to tackle a range of formatting issues.

## Key Ideas

### Toggle

- Check if there exists a node that is not wrapped in the element -> Wrap
- Otherwise -> Unwrap

### Wrap

Iteratate through the DOM tree:

- The element is encountered -> Skip subtree
- A leaf node is reached
  - The leaf node is fully contained in the range: Wrap
  - The leaf node is partially contained in the range: Split and wrap

Normalize the DOM tree.

### Unwrap

Iteratate through the DOM tree:

- The element is encountered
  - The element is fully contained in the range: Unwrap
  - The element is partially contained in the range: Split and unwrap

Normalize the DOM tree.

### Normalize

Normalize the DOM tree to avoid fragmentation:

1. Sort the tree.
2. Merge neighboring identical nodes.

## Remaining Challenges and Taks

- [ ] Handle spell checking and comment nodes
  - Proposal: Normalize after spell checking and comment nodes have been removed
- [ ] Decide on whitespace removal
  - Proposal: Drop support for whitespace removal
- [ ] Preserve ranges without obstructing normalization
  - Proposal: Do not rely on `restoreRange` as it obstructs normalization
- [ ] Sort tags by popularity not lexical order
- [ ] Testing