### PR TITLE
fix: on highlightText dispatch a change event

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -382,7 +382,7 @@ export class Editable {
    */
   highlight ({editableHost, text, highlightId, textRange, raiseEvents, type = 'comment'}) {
     if (!textRange) {
-      return highlightSupport.highlightText(editableHost, text, highlightId, type)
+      return highlightSupport.highlightText(editableHost, text, highlightId, type, raiseEvents ? this.dispatcher : undefined)
     }
     if (typeof textRange.start !== 'number' || typeof textRange.end !== 'number') {
       error(

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -7,7 +7,7 @@ const highlightSupport = {
 
   // Used to highlight arbitrary text in an editable. All occurrences
   // will be highlighted.
-  highlightText (editableHost, text, highlightId, type) {
+  highlightText (editableHost, text, highlightId, type, dispatcher) {
     if (this.hasHighlight(editableHost, highlightId)) return
     const blockText = highlightText.extractText(editableHost)
 
@@ -19,6 +19,7 @@ const highlightSupport = {
     if (matches && matches.length) {
       if (highlightId) matches[0].id = highlightId
       highlightText.highlightMatches(editableHost, matches)
+      if (dispatcher) dispatcher.notify('change', editableHost)
       return matches[0].startIndex
     }
   },


### PR DESCRIPTION
Relations:
- Issue: https://github.com/livingdocsIO/livingdocs-bugs/issues/5225
- Related PRs: https://github.com/livingdocsIO/livingdocs-editor/pull/8659

# Motivation

Using `highlightText` doesn't emit emit a change event.

# Changelog
- 🐛 Fix emit change event on highlightText