### PR TITLE
Smart quotes

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -146,16 +146,11 @@ export default class Dispatcher {
         const block = this.getEditableBlockByEvent(evt)
         if (!block) return
 
-        const target = evt.target
-
-        if (shouldApplySmartQuotes(config, target)) {
-          const currentChar = evt.data
+        if (shouldApplySmartQuotes(config, evt.target)) {
           const selection = this.selectionWatcher.getFreshSelection()
-          const offset = selection.range.startOffset
-          const wholeText = [...target.innerText]
-          const resetCursor = () => this.editable.createCursorAtCharacterOffset({element: block, offset})
-          applySmartQuotes(config, currentChar, wholeText, offset, target, resetCursor)
+          applySmartQuotes(selection.range, config, evt.data, evt.target)
         }
+
         this.notify('change', block)
       })
 

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -89,6 +89,7 @@ export default class Dispatcher {
   * @method setupElementListeners
   */
   setupElementListeners () {
+    const currentInput = {offset: undefined}
     this
       .setupDocumentListener('focus', function focusListener (evt) {
         const block = this.getEditableBlockByEvent(evt)
@@ -148,7 +149,12 @@ export default class Dispatcher {
 
         if (shouldApplySmartQuotes(config, evt.target)) {
           const selection = this.selectionWatcher.getFreshSelection()
-          applySmartQuotes(selection.range, config, evt.data, evt.target)
+          // Save offset of new input, to reset cursor correctly after timeout delay
+          currentInput.offset = selection.range?.startOffset
+          setTimeout(() => {
+            applySmartQuotes(selection.range, config, evt.data, evt.target, currentInput.offset)
+          }, 500
+          )
         }
 
         this.notify('change', block)

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -44,9 +44,13 @@ export const applySmartQuotes = (range, config, char, target, cursorOffset) => {
     return
   }
 
+  const {quotes, singleQuotes} = config
+  if (char === quotes[0] || char === quotes[1] || char === singleQuotes[0] || char === singleQuotes[1]) {
+    return
+  }
+
   const offset = range.startOffset
   const textArr = [...range.startContainer.textContent]
-  const {quotes, singleQuotes} = config
   let newTextNode
 
   if (shouldBeClosingQuote(textArr, offset - 2)) {

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -1,15 +1,43 @@
 const isValidQuotePairConfig = (quotePair) => Array.isArray(quotePair) && quotePair.length === 2
 
-export const shouldApplySmartQuotes = (config) => {
+export const shouldApplySmartQuotes = (config, target) => {
   const {smartQuotes, quotes, singleQuotes} = config
-  return !!smartQuotes && isValidQuotePairConfig(quotes) && isValidQuotePairConfig(singleQuotes)
+  return !!smartQuotes && isValidQuotePairConfig(quotes) && isValidQuotePairConfig(singleQuotes) && target.isContentEditable
 }
 
-export const isQuote = (char) => /^[‘’‹›‚'«»"“”„]$/.test(char)
-export const isDoubleQuote = (char) => /^[«»"“”„]$/.test(char)
-export const isSingleQuote = (char) => /^[‘’‹›‚']$/.test(char)
+// export const isQuote = (char) => /^[‘’‹›‚'«»"“”„]$/.test(char)
+const isDoubleQuote = (char) => /^[«»"“”„]$/.test(char)
+const isSingleQuote = (char) => /^[‘’‹›‚']$/.test(char)
 
 // Test: '>', ' ', no space & all kinds of dashes dash
-export const isOpeningQuote = (text, indexCharBefore) => indexCharBefore < 0 || /\s|[>\-–—]/.test(text[indexCharBefore])
+const isOpeningQuote = (text, indexCharBefore) => indexCharBefore < 0 || /\s|[>\-–—]/.test(text[indexCharBefore])
+const isClosingQuote = (text, indexCharBefore) => text[indexCharBefore] !== ' '
 
-export const isClosingQuote = (text, indexCharBefore) => text[indexCharBefore] !== ' '
+const applySmartQuote = (textArr, index, target, quoteType) => {
+  if (index >= 0 && index < textArr.length) {
+    textArr[index] = quoteType
+    target.innerText = textArr.join('')
+  }
+}
+
+export const applySmartQuotes = (config, char, wholeText, offset, target, resetCursor) => {
+  const isCharSingleQuote = isSingleQuote(char)
+  const isCharDoubleQuote = isDoubleQuote(char)
+
+  if (!isCharDoubleQuote && !isCharSingleQuote) {
+    return
+  }
+
+  const {quotes, singleQuotes} = config
+  if (isClosingQuote(wholeText, offset - 2)) {
+    const closingQuote = isCharSingleQuote ? singleQuotes[1] : quotes[1]
+    applySmartQuote(wholeText, offset - 1, target, closingQuote)
+  }
+
+  if (isOpeningQuote(wholeText, offset - 2)) {
+    const openingQuote = isCharSingleQuote ? singleQuotes[0] : quotes[0]
+    applySmartQuote(wholeText, offset - 1, target, openingQuote)
+  }
+
+  resetCursor()
+}

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -8,11 +8,11 @@ export const shouldApplySmartQuotes = (config, target) => {
 const isDoubleQuote = (char) => /^[«»"“”„]$/.test(char)
 const isSingleQuote = (char) => /^[‘’‹›‚']$/.test(char)
 const isApostrophe = (char) => /^[’']$/.test(char)
+const isWhitespace = (char) => /^\s$/.test(char)
 
-// TODO: Test with: '>', ' ', no space & all kinds of dashes dash
-// edge case: applied tooltip quotes and then inserted single quote after space
 const shouldBeOpeningQuote = (text, indexCharBefore) => indexCharBefore < 0 || /\s|[>\-–—]/.test(text[indexCharBefore])
-const shouldBeClosingQuote = (text, indexCharBefore) => text[indexCharBefore] && !/\s/.test(text[indexCharBefore])
+const shouldBeClosingQuote = (text, indexCharBefore) => !!text[indexCharBefore] && !isWhitespace(text[indexCharBefore])
+const hasCharAfter = (textArr, indexCharAfter) => !!textArr[indexCharAfter] && !isWhitespace(textArr[indexCharAfter])
 
 const replaceQuote = (range, index, quoteType) => {
   const startContainer = range.startContainer
@@ -24,13 +24,6 @@ const replaceQuote = (range, index, quoteType) => {
   return textNode
 }
 
-// TODO: Fix ‹Didn’t› case -> only works with timeout
-const hasCharAfter = (textArr, offset) => {
-  console.log('textArr :>> ', textArr)
-  console.log('offset :>> ', offset)
-  return false
-}
-
 const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
   if (offset <= 0) {
     return false
@@ -38,10 +31,6 @@ const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
   for (let i = offset - 1; i >= 0; i--) {
     if (isSingleQuote(textArr[i]) && (!isApostrophe(singleOpeningQuote) && !isApostrophe(textArr[i]))) {
       return textArr[i] === singleOpeningQuote
-      // TODO: keep on looking for an unclosed single opening quote -> need to save single opening and closing quotes
-      // if (textArr[i] === singleOpeningQuote) {
-      //   return true
-      // }
     }
   }
   return false
@@ -82,10 +71,9 @@ export const applySmartQuotes = (range, config, char, target, carretOffset) => {
     return
   }
 
-  // Resets the cursor
+  // Resets the cursor to the currentPosition after applying the smart-quote
   const window = target.ownerDocument.defaultView
   const selection = window.getSelection()
   selection.collapse(newTextNode, carretOffset ?? offset)
 }
 
-// TODO: fix special case when quickly typing two quotes after each other

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -1,0 +1,15 @@
+const isValidQuotePairConfig = (quotePair) => Array.isArray(quotePair) && quotePair.length === 2
+
+export const shouldApplySmartQuotes = (config) => {
+  const {smartQuotes, quotes, singleQuotes} = config
+  return !!smartQuotes && isValidQuotePairConfig(quotes) && isValidQuotePairConfig(singleQuotes)
+}
+
+export const isQuote = (char) => /^[‘’‹›‚'«»"“”„]$/.test(char)
+export const isDoubleQuote = (char) => /^[«»"“”„]$/.test(char)
+export const isSingleQuote = (char) => /^[‘’‹›‚']$/.test(char)
+
+// Test: '>', ' ', no space & all kinds of dashes dash
+export const isOpeningQuote = (text, indexCharBefore) => indexCharBefore < 0 || /\s|[>\-–—]/.test(text[indexCharBefore])
+
+export const isClosingQuote = (text, indexCharBefore) => text[indexCharBefore] !== ' '

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -36,7 +36,7 @@ const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
   return false
 }
 
-export const applySmartQuotes = (range, config, char, target, carretOffset) => {
+export const applySmartQuotes = (range, config, char, target, cursorOffset) => {
   const isCharSingleQuote = isSingleQuote(char)
   const isCharDoubleQuote = isDoubleQuote(char)
 
@@ -74,6 +74,6 @@ export const applySmartQuotes = (range, config, char, target, carretOffset) => {
   // Resets the cursor to the currentPosition after applying the smart-quote
   const window = target.ownerDocument.defaultView
   const selection = window.getSelection()
-  selection.collapse(newTextNode, carretOffset ?? offset)
+  selection.collapse(newTextNode, cursorOffset ?? offset)
 }
 

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -9,9 +9,10 @@ const isDoubleQuote = (char) => /^[«»"“”„]$/.test(char)
 const isSingleQuote = (char) => /^[‘’‹›‚']$/.test(char)
 const isApostrophe = (char) => /^[’']$/.test(char)
 const isWhitespace = (char) => /^\s$/.test(char)
+const isSeparatorOrWhitespace = (char) => /\s|[>\-–—]/.test(char)
 
-const shouldBeOpeningQuote = (text, indexCharBefore) => indexCharBefore < 0 || /\s|[>\-–—]/.test(text[indexCharBefore])
-const shouldBeClosingQuote = (text, indexCharBefore) => !!text[indexCharBefore] && !isWhitespace(text[indexCharBefore])
+const shouldBeOpeningQuote = (text, indexCharBefore) => indexCharBefore < 0 || isSeparatorOrWhitespace(text[indexCharBefore])
+const shouldBeClosingQuote = (text, indexCharBefore) => !!text[indexCharBefore] && !isSeparatorOrWhitespace(text[indexCharBefore])
 const hasCharAfter = (textArr, indexCharAfter) => !!textArr[indexCharAfter] && !isWhitespace(textArr[indexCharAfter])
 
 const replaceQuote = (range, index, quoteType) => {

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -16,9 +16,19 @@ const shouldBeClosingQuote = (text, indexCharBefore) => text[indexCharBefore] &&
 
 const replaceQuote = (range, index, quoteType) => {
   const startContainer = range.startContainer
+  if (!startContainer.nodeValue) {
+    return
+  }
   const textNode = document.createTextNode(`${startContainer.nodeValue.substring(0, index)}${quoteType}${startContainer.nodeValue.substring(index + 1)}`)
-  range.startContainer.replaceWith(textNode)
+  startContainer.replaceWith(textNode)
   return textNode
+}
+
+// TODO: Fix ‹Didn’t› case -> only works with timeout
+const hasCharAfter = (textArr, offset) => {
+  console.log('textArr :>> ', textArr)
+  console.log('offset :>> ', offset)
+  return false
 }
 
 const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
@@ -28,12 +38,16 @@ const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
   for (let i = offset - 1; i >= 0; i--) {
     if (isSingleQuote(textArr[i]) && (!isApostrophe(singleOpeningQuote) && !isApostrophe(textArr[i]))) {
       return textArr[i] === singleOpeningQuote
+      // TODO: keep on looking for an unclosed single opening quote -> need to save single opening and closing quotes
+      // if (textArr[i] === singleOpeningQuote) {
+      //   return true
+      // }
     }
   }
   return false
 }
 
-export const applySmartQuotes = (range, config, char, target) => {
+export const applySmartQuotes = (range, config, char, target, carretOffset) => {
   const isCharSingleQuote = isSingleQuote(char)
   const isCharDoubleQuote = isDoubleQuote(char)
 
@@ -47,14 +61,16 @@ export const applySmartQuotes = (range, config, char, target) => {
   let newTextNode
 
   if (shouldBeClosingQuote(textArr, offset - 2)) {
-    // Don't transform single-quote if there is no respective single-opening-quote
-    if (isCharSingleQuote && !hasSingleOpeningQuote(textArr, offset, singleQuotes[0])) {
-      return
+    if (isCharSingleQuote) {
+      // Don't transform apostrophes
+      if (hasCharAfter(textArr, offset)) {
+        return
+      }
+      // Don't transform single-quote if there is no respective single-opening-quote
+      if (!hasSingleOpeningQuote(textArr, offset, singleQuotes[0])) {
+        return
+      }
     }
-    // TODO: Fix ‹Didn’t› case -> only works with timeout
-    // if (isCharSingleQuote && hasTextAfter(target, offset)) {
-    //   return
-    // }
     const closingQuote = isCharSingleQuote ? singleQuotes[1] : quotes[1]
     newTextNode = replaceQuote(range, offset - 1, closingQuote)
   } else if (shouldBeOpeningQuote(textArr, offset - 2)) {
@@ -69,5 +85,7 @@ export const applySmartQuotes = (range, config, char, target) => {
   // Resets the cursor
   const window = target.ownerDocument.defaultView
   const selection = window.getSelection()
-  selection.collapse(newTextNode, offset)
+  selection.collapse(newTextNode, carretOffset ?? offset)
 }
+
+// TODO: fix special case when quickly typing two quotes after each other


### PR DESCRIPTION
Relations:

- Basecamp Issue: [Link](https://3.basecamp.com/4910529/buckets/39227833/documents/8027430845)
- Related PR's: [Server PR ](https://github.com/livingdocsIO/livingdocs-server/pull/7695)
- Related PR's: [Editor UI PR ](https://github.com/livingdocsIO/livingdocs-editor/pull/9545)

# Motivation

Enhance text consistency and readability by automatically formatting quotation marks as users type. This ensures they match the configured preferred style.

# How to test

- You need to have `livingdocs-framework`, `livingdocs-server`, `livingdocs-editor` and this branch of `editable.js` locally available
- In [`livingdocs-framework`](https://github.com/livingdocsIO/livingdocs-framework)'s `package.json`, point the `@livingdocs/editable.js` dependency to this local version of `editable.js` and then install dependencies
- Have this PR of [`livingdocs-server`](https://github.com/livingdocsIO/livingdocs-server/pull/7695) checked out and do the same as above for the `@livingdocs/framework` dependency and then install dependencies
- Have this PR of [`livingdocs-editor`](https://github.com/livingdocsIO/livingdocs-editor/pull/9545) checked out and do the same for the `@livingdocs/framework` dependency and then install dependencies
- Start [`livingdocs-server`](https://github.com/livingdocsIO/livingdocs-server/pull/7695) and  [`livingdocs-editor`](https://github.com/livingdocsIO/livingdocs-editor/pull/9545)

# Known Edge Cases

<list or text>

- Finding last, unclosed, single opening quote when typing single closing quote and other single closing quote comes before. E.g. `‹Hello ‹stranger››`
- Return to last cursor position, when no input was done -> keyboard jump 'left' / 'right'
- Smart Quotes is not applied, when Paragraph is switched, before timeout is finished
- Different Range container due to bold/italic/link single closing quote is not applied
- Quickly typing multiple quotes after each other only transforms first typed quote. Due the offset being 0