### PR TITLE
chore: migrate Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
@@ -19,11 +19,11 @@
   "platformAutomerge": true,
   "packageRules": [
     {
-      "matchPackagePatterns": ["babel"],
+      "matchPackageNames": ["/babel/"],
       "groupName": "babel"
     },
     {
-      "matchPackagePatterns": ["karma"],
+      "matchPackageNames": ["/karma/"],
       "groupName": "babel"
     },
     {


### PR DESCRIPTION
## Summary
- migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- replace deprecated `matchPackagePatterns` keys with `matchPackageNames` regex entries, preserving the existing Babel/Karma grouping behavior
- keep the existing dashboard, labels, base branch, schedule, automerge, and rate-limit settings unchanged

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the Config Migration Needed item in the Renovate Dependency Dashboard.