### PR TITLE
Spellcheck: Live check

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,16 +13,16 @@ steps:
       from_secret: GH_TOKEN
 
 - name: install
-  image: cypress/browsers:node16.5.0-chrome94-ff93
+  image: cypress/browsers:node-24.19.0-chrome-151.0.7922.137-1-ff-154.0-edge-151.0.4129.93-1
   commands: [npm ci]
 
 - name: build
-  image: cypress/browsers:node16.5.0-chrome94-ff93
+  image: cypress/browsers:node-24.19.0-chrome-151.0.7922.137-1-ff-154.0-edge-151.0.4129.93-1
   commands: ["npm run build -s"]
   depends_on: [install]
 
 - name: test
-  image: cypress/browsers:node16.5.0-chrome94-ff93
+  image: cypress/browsers:node-24.19.0-chrome-151.0.7922.137-1-ff-154.0-edge-151.0.4129.93-1
   commands: ["npm run test:ci -s"]
   depends_on: [install]
 
@@ -53,6 +53,6 @@ trigger:
   event: [push, tag, pull_request]
 ---
 kind: signature
-hmac: 64cf036f79971de183d6ef916e2098584e731ab3010dbc177a73c3562f2bc73d
+hmac: d25a4656f23b439d08d884af8ba1641d2e32a3c724e28d333f73c2c807c40d4f
 
 ...

--- a/spec/css-highlights.spec.js
+++ b/spec/css-highlights.spec.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 
 import highlightSupport from '../src/highlight-support.js'
+import Selection from '../src/selection.js'
 import {createElement} from '../src/util/dom.js'
 import {
   createCssHighlightRange,
@@ -36,6 +37,13 @@ describe('css highlights', function () {
     for (const host of hosts) host.remove()
     hosts = []
   })
+
+  // Select characters the way a user would, so the formatting runs on a real range.
+  function selectChars (host, start, end) {
+    const range = createCssHighlightRange({editableHost: host, start, end})
+    return new Selection(host, range)
+  }
+
 
   describe('getCssHighlightText()', function () {
     it('reads the text of an editable without its markup', function () {
@@ -116,6 +124,40 @@ describe('css highlights', function () {
       host.textContent = 'Hello world'
       refreshCssHighlights({editableHost: host})
       expect(highlightedText()).to.deep.equal(['world'])
+    })
+
+    it('keeps the highlight on the same words when a format overlaps its start', function () {
+      const host = addEditable('Hello wrold there')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+
+      selectChars(host, 0, 8).toggleBold()
+
+      expect(host.innerHTML).to.equal('<strong>Hello wr</strong>old there')
+      expect(highlightedText()).to.deep.equal(['wrold'])
+    })
+
+    it('keeps the highlight on the same words when a format is applied to it and removed again', function () {
+      const host = addEditable('Hello wrold there')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+
+      selectChars(host, 6, 11).toggleBold()
+      expect(highlightedText()).to.deep.equal(['wrold'])
+
+      selectChars(host, 6, 11).toggleBold()
+      expect(host.innerHTML).to.equal('Hello wrold there')
+      expect(highlightedText()).to.deep.equal(['wrold'])
+    })
+
+    it('keeps the highlight on the same words when a link is added and removed', function () {
+      const host = addEditable('Hello wrold there')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+
+      selectChars(host, 0, 8).link('https://example.com')
+      expect(highlightedText()).to.deep.equal(['wrold'])
+
+      selectChars(host, 0, 8).unlink()
+      expect(host.innerHTML).to.equal('Hello wrold there')
+      expect(highlightedText()).to.deep.equal(['wrold'])
     })
 
     it('forgets editables that left the document', function () {

--- a/spec/css-highlights.spec.js
+++ b/spec/css-highlights.spec.js
@@ -1,0 +1,219 @@
+import {expect} from 'chai'
+
+import highlightSupport from '../src/highlight-support.js'
+import {createElement} from '../src/util/dom.js'
+import {
+  createCssHighlightRange,
+  deleteCssHighlight,
+  getCssHighlightTextOffset,
+  getCssHighlightRects,
+  getCssHighlightText,
+  refreshCssHighlights,
+  setCssHighlight
+} from '../src/plugins/highlighting/css-highlights.js'
+
+const name = 'spellcheck'
+
+describe('css highlights', function () {
+  let hosts = []
+
+  function addEditable (html) {
+    const host = createElement(`<div>${html}</div>`)
+    document.body.appendChild(host)
+    hosts.push(host)
+    return host
+  }
+
+  // The text of every range the browser is painting under our name.
+  function highlightedText () {
+    const highlight = CSS.highlights.get(name)
+    if (!highlight) return undefined
+    return Array.from(highlight, (range) => range.toString())
+  }
+
+  afterEach(function () {
+    deleteCssHighlight({name})
+    for (const host of hosts) host.remove()
+    hosts = []
+  })
+
+  describe('getCssHighlightText()', function () {
+    it('reads the text of an editable without its markup', function () {
+      const host = addEditable('Hello <b>world</b>')
+      expect(getCssHighlightText({editableHost: host})).to.equal('Hello world')
+    })
+
+    it('returns a <br> as a newline', function () {
+      const host = addEditable('Hello<br>world')
+      expect(getCssHighlightText({editableHost: host})).to.equal('Hello\nworld')
+    })
+
+    it('leaves out text marked data-editable="remove"', function () {
+      const host = addEditable('Hello <span data-editable="remove">nope</span>world')
+      expect(getCssHighlightText({editableHost: host})).to.equal('Hello world')
+    })
+  })
+
+  describe('setCssHighlight()', function () {
+    it('highlights a range', function () {
+      const host = addEditable('Hello world')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+      expect(highlightedText()).to.deep.equal(['world'])
+    })
+
+    it('highlights ranges in more than one editable', function () {
+      const first = addEditable('Hello world')
+      const second = addEditable('Hello moon')
+      setCssHighlight({
+        name,
+        ranges: [
+          {editableHost: first, start: 6, end: 11},
+          {editableHost: second, start: 6, end: 10}
+        ]
+      })
+      expect(highlightedText()).to.deep.equal(['world', 'moon'])
+    })
+
+    it('replaces everything set under the same name', function () {
+      const host = addEditable('Hello world')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+      setCssHighlight({name, ranges: [{editableHost: host, start: 0, end: 5}]})
+      expect(highlightedText()).to.deep.equal(['Hello'])
+    })
+
+    it('removes the highlight when no ranges are given', function () {
+      const host = addEditable('Hello world')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+      setCssHighlight({name, ranges: []})
+      expect(highlightedText()).to.equal(undefined)
+    })
+  })
+
+  describe('refreshCssHighlights()', function () {
+    it('keeps the highlight on the same words when a comment is added and removed', function () {
+      const host = addEditable('Hello world')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+
+      highlightSupport.highlightRange(host, undefined, 'before', 0, 5)
+      expect(highlightedText()).to.deep.equal(['world'])
+
+      highlightSupport.highlightRange(host, undefined, 'around', 6, 11)
+      expect(highlightedText()).to.deep.equal(['world'])
+
+      highlightSupport.removeHighlight(host, 'before')
+      highlightSupport.removeHighlight(host, 'around')
+      expect(highlightedText()).to.deep.equal(['world'])
+    })
+
+    it('keeps the offsets while an editable is empty', function () {
+      const host = addEditable('Hello world')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+
+      host.textContent = ''
+      refreshCssHighlights({editableHost: host})
+      expect(highlightedText()).to.equal(undefined)
+
+      host.textContent = 'Hello world'
+      refreshCssHighlights({editableHost: host})
+      expect(highlightedText()).to.deep.equal(['world'])
+    })
+
+    it('forgets editables that left the document', function () {
+      const gone = addEditable('Hello world')
+      const stays = addEditable('Hello moon')
+      setCssHighlight({
+        name,
+        ranges: [
+          {editableHost: gone, start: 6, end: 11},
+          {editableHost: stays, start: 6, end: 10}
+        ]
+      })
+
+      gone.remove()
+      refreshCssHighlights({editableHost: stays})
+      expect(highlightedText()).to.deep.equal(['moon'])
+    })
+  })
+
+  describe('deleteCssHighlight()', function () {
+    it('removes the highlight and forgets where it was', function () {
+      const host = addEditable('Hello world')
+      setCssHighlight({name, ranges: [{editableHost: host, start: 6, end: 11}]})
+
+      deleteCssHighlight({name})
+      expect(highlightedText()).to.equal(undefined)
+
+      refreshCssHighlights({editableHost: host})
+      expect(highlightedText()).to.equal(undefined)
+    })
+  })
+
+  describe('createCssHighlightRange()', function () {
+    it('returns a range over the given characters', function () {
+      const host = addEditable('Hello world')
+      const range = createCssHighlightRange({editableHost: host, start: 6, end: 11})
+      expect(range.toString()).to.equal('world')
+    })
+
+    it('returns a range that reaches across elements', function () {
+      const host = addEditable('<b>Hello</b> world')
+      const range = createCssHighlightRange({editableHost: host, start: 3, end: 8})
+      expect(range.toString()).to.equal('lo wo')
+    })
+
+    it('returns nothing for offsets past the end of the text', function () {
+      const host = addEditable('Hello world')
+      const range = createCssHighlightRange({editableHost: host, start: 20, end: 25})
+      expect(range).to.equal(undefined)
+    })
+  })
+
+  describe('getCssHighlightRects()', function () {
+    it('returns where the characters sit on screen', function () {
+      const host = addEditable('Hello world')
+      const {bounding, rects} = getCssHighlightRects({editableHost: host, start: 6, end: 11})
+
+      expect(rects).to.have.lengthOf(1)
+      expect(bounding.width).to.be.above(0)
+      expect(bounding.height).to.be.above(0)
+    })
+
+    it('returns nothing for offsets past the end of the text', function () {
+      const host = addEditable('Hello world')
+      expect(getCssHighlightRects({editableHost: host, start: 20, end: 25})).to.equal(undefined)
+    })
+  })
+
+  describe('getCssHighlightTextOffset()', function () {
+    it('counts the same characters as getCssHighlightText()', function () {
+      const host = addEditable('Hello<br><b>world</b>')
+      const container = host.querySelector('b').firstChild
+
+      const offset = getCssHighlightTextOffset({
+        editableHost: host, container, containerOffset: 2
+      })
+
+      expect(offset).to.equal(8)
+    })
+
+    it('returns the offset of the child a position in an element points at', function () {
+      const host = addEditable('Hello <b>world</b>')
+
+      const offset = getCssHighlightTextOffset({
+        editableHost: host, container: host, containerOffset: 1
+      })
+
+      expect(offset).to.equal(6)
+    })
+
+    it('returns the end of the block for a position after the last child', function () {
+      const host = addEditable('Hello <b>world</b>')
+
+      const offset = getCssHighlightTextOffset({
+        editableHost: host, container: host, containerOffset: host.childNodes.length
+      })
+
+      expect(offset).to.equal(11)
+    })
+  })
+})

--- a/spec/range-save-restore.spec.js
+++ b/spec/range-save-restore.spec.js
@@ -59,7 +59,7 @@ describe('RangeSaveRestore', function () {
     // the range is added outside the element instead of inside where the text node is
     // (compare with the previous test).
     expect(host.innerHTML)
-      .to.equal(`<span id="editable-range-boundary-35" data-editable="remove" style="line-height: 0; display: none;">\ufeff</span><em>a</em><em>b</em><span id="editable-range-boundary-34" data-editable="remove" style="line-height: 0; display: none;">\ufeff</span>`)
+      .to.equal(`<span id="${savedRange.startMarkerId}" data-editable="remove" style="line-height: 0; display: none;">\ufeff</span><em>a</em><em>b</em><span id="${savedRange.endMarkerId}" data-editable="remove" style="line-height: 0; display: none;">\ufeff</span>`)
 
     rangeSaveRestore.restore(host, savedRange)
 

--- a/spec/smartQuotes.spec.js
+++ b/spec/smartQuotes.spec.js
@@ -1,5 +1,7 @@
 import {expect} from 'chai'
 import {isDoubleQuote, isSingleQuote, isWhitespace, isSeparatorOrWhitespace, isApostrophe, replaceQuote} from '../src/smartQuotes'
+import {createElement} from '../src/util/dom.js'
+import {deleteCssHighlight, setCssHighlight} from '../src/plugins/highlighting/css-highlights.js'
 
 const allSingleQuotes = ['‘', '’', '‹', '›', '‚', '‘', '›', '‹', `'`, `‘`]
 const allDoubleQuotes = ['«', '»', '»', '«', '"', '"', '“', '”', '”', '”', '“', '“', '„', '“']
@@ -93,24 +95,86 @@ describe('replaceQuote(): ', () => {
 
   it('should replace quote at given index', () => {
     const range = createRangeWithText(testString)
-    const replacedTextNode = replaceQuote(range, index, '`')
-    expect(replacedTextNode.textContent).to.equal('123 `you')
+    expect(replaceQuote(range, index, '`')).to.equal(true)
+    expect(range.startContainer.textContent).to.equal('123 `you')
   })
 
-  it('should return null if range is invalid', () => {
-    const invalidNodeValue = replaceQuote(undefined, index, '`')
-    expect(invalidNodeValue).to.equal(null)
+  it('should return false if range is invalid', () => {
+    expect(replaceQuote(undefined, index, '`')).to.equal(false)
   })
 
-  it('should return null if range is empty', () => {
+  it('should return false if range is empty', () => {
     const range = createRangeWithText('')
-    const replacedTextNode = replaceQuote(range, 0, '`')
-    expect(replacedTextNode).to.equal(null)
+    expect(replaceQuote(range, 0, '`')).to.equal(false)
+    expect(range.startContainer.textContent).to.equal('')
   })
 
   it('should insert quote at the end, if index is out of bounds', () => {
     const range = createRangeWithText(testString)
-    const replacedTextNode = replaceQuote(range, 40, '`')
-    expect(replacedTextNode.textContent).to.equal(`${testString}${'`'}`)
+    expect(replaceQuote(range, 40, '`')).to.equal(true)
+    expect(range.startContainer.textContent).to.equal(`${testString}${'`'}`)
+  })
+
+  describe('with a css highlight', () => {
+    const highlightName = 'spellcheck'
+    let host
+
+    beforeEach(() => {
+      host = createElement(`<div>${testString}</div>`)
+      document.body.appendChild(host)
+    })
+
+    afterEach(() => {
+      deleteCssHighlight({name: highlightName})
+      host.remove()
+    })
+
+    const highlight = (start, end) => {
+      setCssHighlight({name: highlightName, ranges: [{editableHost: host, start, end}]})
+    }
+
+    const replaceQuoteInHost = () => {
+      const range = document.createRange()
+      range.selectNodeContents(host.firstChild)
+      replaceQuote(range, index, '`')
+    }
+
+    const highlightedTexts = () => Array.from(CSS.highlights.get(highlightName), (r) => r.toString())
+
+    it('should keep a highlight around the quote', () => {
+      highlight(3, 6)
+
+      replaceQuoteInHost()
+
+      expect(host.textContent).to.equal('123 `you')
+      expect(highlightedTexts()).to.deep.equal([' `y'])
+    })
+
+    it('should keep a highlight away from the quote', () => {
+      highlight(0, 3)
+
+      replaceQuoteInHost()
+
+      expect(host.textContent).to.equal('123 `you')
+      expect(highlightedTexts()).to.deep.equal(['123'])
+    })
+
+    it('should keep a highlight starting right after the quote', () => {
+      highlight(5, 8)
+
+      replaceQuoteInHost()
+
+      expect(host.textContent).to.equal('123 `you')
+      expect(highlightedTexts()).to.deep.equal(['you'])
+    })
+
+    it('should keep a highlight ending right before the quote', () => {
+      highlight(0, 4)
+
+      replaceQuoteInHost()
+
+      expect(host.textContent).to.equal('123 `you')
+      expect(highlightedTexts()).to.deep.equal(['123 '])
+    })
   })
 })

--- a/src/content.js
+++ b/src/content.js
@@ -2,6 +2,7 @@ import * as nodeType from './node-type.js'
 import * as rangeSaveRestore from './range-save-restore.js'
 import * as parser from './parser.js'
 import * as string from './util/string.js'
+import {refreshCssHighlights} from './plugins/highlighting/css-highlights.js'
 import {createElement, createRange, getNodes, normalizeBoundaries, splitBoundaries, containsNodeText} from './util/dom.js'
 import config from './config.js'
 
@@ -343,6 +344,7 @@ export function forceWrap (host, range, elem) {
   }
 
   wrap(restoredRange, elem)
+  refreshCssHighlights({editableHost: host})
   return restoredRange
 }
 
@@ -364,15 +366,19 @@ export function unwrap (elem) {
 }
 
 export function removeFormattingElem (host, range, elem) {
-  return restoreRange(host, range, () => {
+  const restoredRange = restoreRange(host, range, () => {
     nukeElem(host, range, elem)
   })
+  refreshCssHighlights({editableHost: host})
+  return restoredRange
 }
 
 export function removeFormatting (host, range, selector) {
-  return restoreRange(host, range, () => {
+  const restoredRange = restoreRange(host, range, () => {
     nuke(host, range, selector)
   })
+  refreshCssHighlights({editableHost: host})
+  return restoredRange
 }
 
 // Unwrap all tags this range is affected by.

--- a/src/core.js
+++ b/src/core.js
@@ -12,10 +12,10 @@ import Selection from './selection.js'
 import {
   getCssHighlightText,
   setCssHighlight,
-  clearCssHighlight,
+  deleteCssHighlight,
   createCssHighlightRange,
   getCssHighlightRects,
-  findCharacterOffset
+  getCssHighlightTextOffset
 } from './plugins/highlighting/css-highlights.js'
 import createDefaultEvents from './create-default-events.js'
 import {textNodesUnder, getTextNodeAndRelativeOffset} from './util/element.js'
@@ -438,11 +438,12 @@ export class Editable {
   }
 
   /**
-   * @param  {DOMNode} editableHost
+   * @param  {Object} options
+   * @param  {DOMNode} options.editableHost
    * @return {String}
    */
-  getCssHighlightText (editableHost) {
-    return getCssHighlightText(editableHost)
+  getCssHighlightText ({editableHost}) {
+    return getCssHighlightText({editableHost})
   }
 
   /**
@@ -461,43 +462,19 @@ export class Editable {
    * @param {Object} options
    * @param {String} options.name
    */
-  clearCssHighlight ({name}) {
-    clearCssHighlight({name, win: this.win})
+  deleteCssHighlight ({name}) {
+    deleteCssHighlight({name, win: this.win})
   }
 
   /**
-   * @param {Object} options
-   * @param {DOMNode} options.editableHost
-   * @param {Number} options.start
-   * @param {Number} options.end
-   * @return {Range|undefined}
-   */
-  getCssHighlightRange ({editableHost, start, end}) {
-    return createCssHighlightRange({editableHost, start, end, win: this.win})
-  }
-
-  /**
-   * @param {Object} options
-   * @param {DOMNode} options.editableHost
-   * @param {Number} options.start
-   * @param {Number} options.end
-   * @return {Object|undefined} {bounding, rects}
-   */
-  getCssHighlightRects ({editableHost, start, end}) {
-    return getCssHighlightRects({editableHost, start, end, win: this.win})
-  }
-
-  /**
-   * Swap the text under a highlight for something else.
-   *
    * @param {Object} options
    * @param {DOMNode} options.editableHost
    * @param {Number} options.start
    * @param {Number} options.end
    * @param {String} options.text
-   * @return {Boolean} Whether the replacement happened.
+   * @return {Boolean}
    */
-  replaceCssHighlightRange ({editableHost, start, end, text}) {
+  replaceCssHighlight ({editableHost, start, end, text}) {
     const range = createCssHighlightRange({editableHost, start, end, win: this.win})
     if (!range) return false
 
@@ -507,15 +484,31 @@ export class Editable {
   }
 
   /**
-   * @param  {DOMNode} editableHost
+   * @param {Object} options
+   * @param {DOMNode} options.editableHost
+   * @param {Number} options.start
+   * @param {Number} options.end
+   * @return {Object|undefined}
+   */
+  getCssHighlightRects ({editableHost, start, end}) {
+    return getCssHighlightRects({editableHost, start, end, win: this.win})
+  }
+
+  /**
+   * @param  {Object} options
+   * @param  {DOMNode} options.editableHost
    * @return {Number|undefined}
    */
-  getCssHighlightCursorOffset (editableHost) {
+  getCssHighlightCursorOffset ({editableHost}) {
     const cursor = this.getSelection(editableHost)
     if (!cursor?.isCursor) return
 
     const {startContainer, startOffset} = cursor.range
-    return findCharacterOffset(editableHost, startContainer, startOffset)
+    return getCssHighlightTextOffset({
+      editableHost,
+      container: startContainer,
+      containerOffset: startOffset
+    })
   }
 
   /**

--- a/src/core.js
+++ b/src/core.js
@@ -8,6 +8,12 @@ import Dispatcher from './dispatcher.js'
 import Cursor from './cursor.js'
 import highlightSupport from './highlight-support.js'
 import MonitoredHighlighting from './monitored-highlighting.js'
+import {
+  getCssHighlightText,
+  setCssHighlight,
+  clearCssHighlight,
+  findCharacterOffset
+} from './plugins/highlighting/css-highlights.js'
 import createDefaultEvents from './create-default-events.js'
 import {textNodesUnder, getTextNodeAndRelativeOffset} from './util/element.js'
 import {binaryCursorSearch} from './util/binary_search.js'
@@ -426,6 +432,46 @@ export class Editable {
 
   decorateHighlight ({editableHost, highlightId, addCssClass, removeCssClass}) {
     highlightSupport.updateHighlight(editableHost, highlightId, addCssClass, removeCssClass)
+  }
+
+  /**
+   * @param  {DOMNode} editableHost
+   * @return {String}
+   */
+  getCssHighlightText (editableHost) {
+    return getCssHighlightText(editableHost)
+  }
+
+  /**
+   * @param {Object} options
+   * @param {String} options.name
+   * @param {Array} [options.ranges]
+   * @param {DOMNode} options.ranges[].editableHost
+   * @param {Number} options.ranges[].start
+   * @param {Number} options.ranges[].end
+   */
+  setCssHighlight ({name, ranges = []}) {
+    setCssHighlight({name, ranges, win: this.win})
+  }
+
+  /**
+   * @param {Object} options
+   * @param {String} options.name
+   */
+  clearCssHighlight ({name}) {
+    clearCssHighlight({name, win: this.win})
+  }
+
+  /**
+   * @param  {DOMNode} editableHost
+   * @return {Number|undefined}
+   */
+  getCssHighlightCursorOffset (editableHost) {
+    const cursor = this.getSelection(editableHost)
+    if (!cursor?.isCursor) return
+
+    const {startContainer, startOffset} = cursor.range
+    return findCharacterOffset(editableHost, startContainer, startOffset)
   }
 
   /**

--- a/src/core.js
+++ b/src/core.js
@@ -8,10 +8,13 @@ import Dispatcher from './dispatcher.js'
 import Cursor from './cursor.js'
 import highlightSupport from './highlight-support.js'
 import MonitoredHighlighting from './monitored-highlighting.js'
+import Selection from './selection.js'
 import {
   getCssHighlightText,
   setCssHighlight,
   clearCssHighlight,
+  createCssHighlightRange,
+  getCssHighlightRects,
   findCharacterOffset
 } from './plugins/highlighting/css-highlights.js'
 import createDefaultEvents from './create-default-events.js'
@@ -460,6 +463,47 @@ export class Editable {
    */
   clearCssHighlight ({name}) {
     clearCssHighlight({name, win: this.win})
+  }
+
+  /**
+   * @param {Object} options
+   * @param {DOMNode} options.editableHost
+   * @param {Number} options.start
+   * @param {Number} options.end
+   * @return {Range|undefined}
+   */
+  getCssHighlightRange ({editableHost, start, end}) {
+    return createCssHighlightRange({editableHost, start, end, win: this.win})
+  }
+
+  /**
+   * @param {Object} options
+   * @param {DOMNode} options.editableHost
+   * @param {Number} options.start
+   * @param {Number} options.end
+   * @return {Object|undefined} {bounding, rects}
+   */
+  getCssHighlightRects ({editableHost, start, end}) {
+    return getCssHighlightRects({editableHost, start, end, win: this.win})
+  }
+
+  /**
+   * Swap the text under a highlight for something else.
+   *
+   * @param {Object} options
+   * @param {DOMNode} options.editableHost
+   * @param {Number} options.start
+   * @param {Number} options.end
+   * @param {String} options.text
+   * @return {Boolean} Whether the replacement happened.
+   */
+  replaceCssHighlightRange ({editableHost, start, end, text}) {
+    const range = createCssHighlightRange({editableHost, start, end, win: this.win})
+    if (!range) return false
+
+    const cursor = new Selection(editableHost, range).insertCharacter(text)
+    cursor.triggerChange()
+    return true
   }
 
   /**

--- a/src/highlight-support.js
+++ b/src/highlight-support.js
@@ -1,5 +1,6 @@
 import * as content from './content.js'
 import highlightText from './highlight-text.js'
+import {refreshCssHighlights} from './plugins/highlighting/css-highlights.js'
 import {searchText} from './plugins/highlighting/text-search.js'
 import {createElement, createRange, toCharacterRange} from './util/dom.js'
 
@@ -19,6 +20,7 @@ const highlightSupport = {
     if (matches && matches.length) {
       if (highlightId) matches[0].id = highlightId
       highlightText.highlightMatches(editableHost, matches)
+      refreshCssHighlights({editableHost})
       if (dispatcher) dispatcher.notify('change', editableHost)
       return matches[0].startIndex
     }
@@ -61,6 +63,8 @@ const highlightSupport = {
       marker
     }], false)
 
+    refreshCssHighlights({editableHost})
+
     if (dispatcher) dispatcher.notify('change', editableHost)
 
     return startIndex
@@ -84,6 +88,8 @@ const highlightSupport = {
 
     // remove empty text nodes, combine adjacent text nodes
     editableHost.normalize()
+
+    refreshCssHighlights({editableHost})
 
     if (dispatcher) dispatcher.notify('change', editableHost)
   },

--- a/src/plugins/highlighting/css-highlights.js
+++ b/src/plugins/highlighting/css-highlights.js
@@ -1,9 +1,10 @@
 import NodeIterator from '../../node-iterator.js'
 import * as nodeType from '../../node-type.js'
 import {createRange} from '../../util/dom.js'
+import {getScrollPosition} from '../../util/viewport.js'
 
 /**
- * Read an editable as one flat string. Callers place marks by character
+ * Read an editable as one flat string. Callers place highlights by character
  * offset, so they need a view of the block with no markup in it. Elements
  * fall away, a <br> becomes a newline, and parts of the block that are
  * marked data-editable="remove" are left out.
@@ -23,8 +24,9 @@ export function getCssHighlightText (element) {
 }
 
 /**
- * Mark parts of an editable without touching its content. Marks like spell
- * errors are not part of the document, so they should not end up in the DOM.
+ * Highlight parts of an editable without touching its content. Highlights like
+ * spell errors are not part of the document, so they should not end up in the
+ * DOM.
  *
  * @param  {Object} options
  * @param  {String} options.name
@@ -69,8 +71,8 @@ export function createCssHighlightRange ({editableHost, start, end, win = window
 }
 
 /**
- * Take away all marks of a kind. The registry belongs to the window, not to
- * an editable, so marks stay around until someone removes them.
+ * Remove all highlights of one kind. The registry belongs to the window, not
+ * to an editable, so highlights stay around until someone removes them.
  *
  * @param  {Object} options
  * @param  {String} options.name
@@ -81,9 +83,32 @@ export function clearCssHighlight ({name, win = window}) {
 }
 
 /**
- * Count how far into a block a DOM position sits, the other way round from
+ * Where a highlight is positioned on screen.
+ *
+ * @param  {Object} options
+ * @param  {DOMNode} options.editableHost
+ * @param  {Number} options.start
+ * @param  {Number} options.end
+ * @param  {Window} [options.win]
+ * @return {Object|undefined}
+ */
+export function getCssHighlightRects ({editableHost, start, end, win = window}) {
+  const range = createCssHighlightRange({editableHost, start, end, win})
+  if (!range) return
+
+  const bounding = range.getBoundingClientRect()
+  const rects = Array.from(range.getClientRects())
+  const {x, y} = getScrollPosition(win)
+  return {
+    bounding: translate(bounding, x, y),
+    rects: rects.map((rect) => translate(rect, x, y))
+  }
+}
+
+/**
+ * Count how far into a block a DOM position sits, the inverse of
  * findRangeBoundary(). Counts the same characters as getCssHighlightText() so
- * that a cursor and a mark agree on where they are.
+ * that a cursor and a highlight agree on where they are.
  *
  * @param  {DOMNode} element
  * @param  {DOMNode} container
@@ -150,5 +175,24 @@ function findRangeBoundary (element, target, inclusive) {
     }
 
     offset = nodeEnd
+  }
+}
+
+/**
+ * Shift a rect by a scroll offset.
+ *
+ * @param  {DOMRect} rect
+ * @param  {Number} x
+ * @param  {Number} y
+ * @return {Object}
+ */
+function translate (rect, x, y) {
+  return {
+    top: rect.top + y,
+    bottom: rect.bottom + y,
+    left: rect.left + x,
+    right: rect.right + x,
+    width: rect.width,
+    height: rect.height
   }
 }

--- a/src/plugins/highlighting/css-highlights.js
+++ b/src/plugins/highlighting/css-highlights.js
@@ -3,19 +3,28 @@ import * as nodeType from '../../node-type.js'
 import {createRange} from '../../util/dom.js'
 import {getScrollPosition} from '../../util/viewport.js'
 
+// The DOM ranges in CSS.highlights do not survive markup changes, so keep the
+// character offsets and redraw from those. One registry per window, because
+// this module is shared by every editable on the page while CSS.highlights is
+// not.
+//
+// win -> Map(name -> Map(editableHost -> [{start, end}]))
+const registries = new WeakMap()
+
 /**
- * Read an editable as one flat string. Callers place highlights by character
- * offset, so they need a view of the block with no markup in it. Elements
- * fall away, a <br> becomes a newline, and parts of the block that are
- * marked data-editable="remove" are left out.
+ * Read an editable as plain text. Callers work in character offsets, so they
+ * need the text those offsets count against. A <br> counts as a newline,
+ * otherwise the words around it would run together. Text marked
+ * data-editable="remove" is left out.
  *
- * @param  {DOMNode} element
+ * @param  {Object} options
+ * @param  {DOMNode} options.editableHost
  * @return {String}
  */
-export function getCssHighlightText (element) {
+export function getCssHighlightText ({editableHost}) {
   let text = ''
 
-  for (const node of new NodeIterator(element)) {
+  for (const node of new NodeIterator(editableHost)) {
     if (node.nodeType === nodeType.textNode) text += node.data
     else if (node.nodeName === 'BR') text += '\n'
   }
@@ -24,9 +33,12 @@ export function getCssHighlightText (element) {
 }
 
 /**
- * Highlight parts of an editable without touching its content. Highlights like
- * spell errors are not part of the document, so they should not end up in the
- * DOM.
+ * Highlight parts of an editable without touching its content. Spell errors
+ * are not part of the document, so they must not end up in the DOM.
+ *
+ * Each call replaces everything held under that name. The offsets are kept so
+ * the highlight can be drawn again after someone else changes the markup.
+ * Passing no ranges removes the highlight.
  *
  * @param  {Object} options
  * @param  {String} options.name
@@ -37,20 +49,55 @@ export function getCssHighlightText (element) {
  * @param  {Window} [options.win]
  */
 export function setCssHighlight ({name, ranges = [], win = window}) {
-  const domRanges = []
+  const hosts = new Map()
   for (const {editableHost, start, end} of ranges) {
-    const range = createCssHighlightRange({editableHost, start, end, win})
-    if (range) domRanges.push(range)
+    const offsets = hosts.get(editableHost)
+    if (offsets) offsets.push({start, end})
+    else hosts.set(editableHost, [{start, end}])
   }
 
-  if (!domRanges.length) return clearCssHighlight({name, win})
+  if (!hosts.size) return deleteCssHighlight({name, win})
 
-  win.CSS.highlights.set(name, new win.Highlight(...domRanges))
+  let registry = registries.get(win)
+  if (!registry) registries.set(win, registry = new Map())
+  registry.set(name, hosts)
+
+  drawCssHighlight({name, hosts, win})
 }
 
 /**
- * Turn a character range into a DOM range. Everything else in this file goes
- * through here, so there is one place where offsets meet the DOM.
+ * Draw the highlights of an editable again after its markup changed.
+ *
+ * Comments and formats wrap text in marker nodes, which breaks the ranges the
+ * browser is holding. The markers carry no text themselves, so the offsets
+ * still point at the right words and the highlight can be rebuilt from them.
+ *
+ * @param  {Object} options
+ * @param  {DOMNode} options.editableHost
+ * @param  {Window} [options.win]
+ */
+export function refreshCssHighlights ({
+  editableHost,
+  win = editableHost?.ownerDocument?.defaultView
+}) {
+  const registry = registries.get(win)
+  if (!registry?.size) return
+
+  for (const [name, hosts] of registry) {
+    if (!hosts.has(editableHost)) continue
+
+    for (const host of hosts.keys()) {
+      if (!host?.isConnected) hosts.delete(host)
+    }
+
+    if (!hosts.size) deleteCssHighlight({name, win})
+    else drawCssHighlight({name, hosts, win})
+  }
+}
+
+/**
+ * Turn a character range into a DOM range, for callers that need to select or
+ * measure the text rather than highlight it.
  *
  * @param  {Object} options
  * @param  {DOMNode} options.editableHost
@@ -60,30 +107,26 @@ export function setCssHighlight ({name, ranges = [], win = window}) {
  * @return {Range|undefined}
  */
 export function createCssHighlightRange ({editableHost, start, end, win = window}) {
-  const startPoint = findRangeBoundary(editableHost, start, false)
-  const endPoint = findRangeBoundary(editableHost, end, true)
-  if (!startPoint || !endPoint) return
-
-  const range = createRange(win)
-  range.setStart(startPoint.node, startPoint.offset)
-  range.setEnd(endPoint.node, endPoint.offset)
-  return range
+  const segments = collectTextSegments(editableHost)
+  return createRangeFromSegments({segments, start, end, win})
 }
 
 /**
- * Remove all highlights of one kind. The registry belongs to the window, not
- * to an editable, so highlights stay around until someone removes them.
+ * Remove the highlights of one name and forget where they were. Nothing does
+ * this on its own, so whoever set them has to say when they are done.
  *
  * @param  {Object} options
  * @param  {String} options.name
  * @param  {Window} [options.win]
  */
-export function clearCssHighlight ({name, win = window}) {
+export function deleteCssHighlight ({name, win = window}) {
+  registries.get(win)?.delete(name)
   win.CSS.highlights.delete(name)
 }
 
 /**
- * Where a highlight is positioned on screen.
+ * Where a range sits on screen, so a caller can place something next to it.
+ * The coordinates include the scroll offset.
  *
  * @param  {Object} options
  * @param  {DOMNode} options.editableHost
@@ -106,23 +149,24 @@ export function getCssHighlightRects ({editableHost, start, end, win = window}) 
 }
 
 /**
- * Count how far into a block a DOM position sits, the inverse of
- * findRangeBoundary(). Counts the same characters as getCssHighlightText() so
- * that a cursor and a highlight agree on where they are.
+ * Turn a DOM position into a character offset, so a caller can tell which
+ * highlight a position falls in. Counts the same characters as
+ * getCssHighlightText(), so the two always agree on where an offset falls.
  *
- * @param  {DOMNode} element
- * @param  {DOMNode} container
- * @param  {Number} containerOffset
+ * @param  {Object} options
+ * @param  {DOMNode} options.editableHost
+ * @param  {DOMNode} options.container
+ * @param  {Number} options.containerOffset
  * @return {Number|undefined}
  */
-export function findCharacterOffset (element, container, containerOffset) {
-  // A position in an element sits before one of its children rather than
-  // inside text. Resolve it to that child so the walk can recognise it.
+export function getCssHighlightTextOffset ({editableHost, container, containerOffset}) {
+  // A position in an element points before one of its children instead of
+  // into text. Resolve it to that child so the walk can spot it.
   const beforeNode = container.nodeType === nodeType.elementNode
     ? container.childNodes[containerOffset]
     : undefined
 
-  const iterator = new NodeIterator(element)
+  const iterator = new NodeIterator(editableHost)
 
   let offset = 0
   let next
@@ -140,42 +184,112 @@ export function findCharacterOffset (element, container, containerOffset) {
     offset = offset + next.data.length
   }
 
-  // Ran off the end without meeting the container. That is the position after
-  // the last character when it came from an element, and a container the walk
-  // does not count otherwise.
+  // The walk never met the container. For an element that means the end of the
+  // block. Anything else is a node we do not count, so there is no offset.
   if (!beforeNode && container.nodeType === nodeType.elementNode) return offset
 }
 
 /**
- * Find the spot in the DOM that a character offset points at. Callers count
- * characters, the browser wants nodes. This reads the block the same way as
- * getCssHighlightText(), so both agree on where an offset falls.
+ * Render one named highlight from character offsets.
+ *
+ * @param  {Object} options
+ * @param  {String} options.name
+ * @param  {Map} options.hosts editableHost -> [{start, end}]
+ * @param  {Window} options.win
+ */
+function drawCssHighlight ({name, hosts, win}) {
+  const domRanges = []
+
+  for (const [editableHost, offsets] of hosts) {
+    const segments = collectTextSegments(editableHost)
+    if (!segments.length) continue
+
+    for (const {start, end} of offsets) {
+      const range = createRangeFromSegments({segments, start, end, win})
+      if (range) domRanges.push(range)
+    }
+  }
+
+  // Keep the offsets. An editable can be empty for a moment while it renders,
+  // which does not mean the highlight has gone away.
+  if (!domRanges.length) return win.CSS.highlights.delete(name)
+
+  win.CSS.highlights.set(name, new win.Highlight(...domRanges))
+}
+
+/**
+ * List the text nodes of an editable with the offsets each one covers. Reading
+ * the block once serves any number of lookups, and it is read the same way as
+ * getCssHighlightText() so the two agree on where an offset falls.
  *
  * @param  {DOMNode} element
+ * @return {Array} [{node, start, end}] ordered and non overlapping
+ */
+function collectTextSegments (element) {
+  const segments = []
+  let offset = 0
+
+  for (const node of new NodeIterator(element)) {
+    if (node.nodeType === nodeType.elementNode && node.nodeName === 'BR') {
+      offset += 1
+      continue
+    }
+    if (node.nodeType !== nodeType.textNode || node.data === '') continue
+
+    const end = offset + node.data.length
+    segments.push({node, start: offset, end})
+    offset = end
+  }
+
+  return segments
+}
+
+/**
+ * @param  {Object} options
+ * @param  {Array} options.segments
+ * @param  {Number} options.start
+ * @param  {Number} options.end
+ * @param  {Window} options.win
+ * @return {Range|undefined}
+ */
+function createRangeFromSegments ({segments, start, end, win}) {
+  const startPoint = findRangeBoundary(segments, start, false)
+  const endPoint = findRangeBoundary(segments, end, true)
+  if (!startPoint || !endPoint) return
+
+  const range = createRange(win)
+  range.setStart(startPoint.node, startPoint.offset)
+  range.setEnd(endPoint.node, endPoint.offset)
+  return range
+}
+
+/**
+ * Find the place in the DOM that a character offset points at. Callers count
+ * characters, the browser wants nodes.
+ *
+ * Segments only ever move forward, so the right one can be found without
+ * reading them all.
+ *
+ * @param  {Array} segments
  * @param  {Number} target
  * @param  {Boolean} inclusive True for a range end, false for a range start.
  * @return {Object|undefined}
  */
-function findRangeBoundary (element, target, inclusive) {
-  const iterator = new NodeIterator(element)
+function findRangeBoundary (segments, target, inclusive) {
+  let low = 0
+  let high = segments.length
 
-  let offset = 0
-  let next
-
-  while ((next = iterator.getNext())) {
-    if (next.nodeType === nodeType.elementNode && next.nodeName === 'BR') {
-      offset += 1
-      continue
-    }
-    if (next.nodeType !== nodeType.textNode || next.data === '') continue
-
-    const nodeEnd = offset + next.data.length
-    if (inclusive ? nodeEnd >= target : nodeEnd > target) {
-      return {node: next, offset: Math.max(0, target - offset)}
-    }
-
-    offset = nodeEnd
+  while (low < high) {
+    const middle = (low + high) >> 1
+    const {end} = segments[middle]
+    if (inclusive ? end >= target : end > target) high = middle
+    else low = middle + 1
   }
+
+  const segment = segments[low]
+  if (!segment) return
+
+  return {node: segment.node, offset: Math.max(0, target - segment.start)}
 }
 
 /**

--- a/src/plugins/highlighting/css-highlights.js
+++ b/src/plugins/highlighting/css-highlights.js
@@ -1,0 +1,154 @@
+import NodeIterator from '../../node-iterator.js'
+import * as nodeType from '../../node-type.js'
+import {createRange} from '../../util/dom.js'
+
+/**
+ * Read an editable as one flat string. Callers place marks by character
+ * offset, so they need a view of the block with no markup in it. Elements
+ * fall away, a <br> becomes a newline, and parts of the block that are
+ * marked data-editable="remove" are left out.
+ *
+ * @param  {DOMNode} element
+ * @return {String}
+ */
+export function getCssHighlightText (element) {
+  let text = ''
+
+  for (const node of new NodeIterator(element)) {
+    if (node.nodeType === nodeType.textNode) text += node.data
+    else if (node.nodeName === 'BR') text += '\n'
+  }
+
+  return text
+}
+
+/**
+ * Mark parts of an editable without touching its content. Marks like spell
+ * errors are not part of the document, so they should not end up in the DOM.
+ *
+ * @param  {Object} options
+ * @param  {String} options.name
+ * @param  {Array} [options.ranges]
+ * @param  {DOMNode} options.ranges[].editableHost
+ * @param  {Number} options.ranges[].start
+ * @param  {Number} options.ranges[].end
+ * @param  {Window} [options.win]
+ */
+export function setCssHighlight ({name, ranges = [], win = window}) {
+  const domRanges = []
+  for (const {editableHost, start, end} of ranges) {
+    const range = createCssHighlightRange({editableHost, start, end, win})
+    if (range) domRanges.push(range)
+  }
+
+  if (!domRanges.length) return clearCssHighlight({name, win})
+
+  win.CSS.highlights.set(name, new win.Highlight(...domRanges))
+}
+
+/**
+ * Turn a character range into a DOM range. Everything else in this file goes
+ * through here, so there is one place where offsets meet the DOM.
+ *
+ * @param  {Object} options
+ * @param  {DOMNode} options.editableHost
+ * @param  {Number} options.start
+ * @param  {Number} options.end
+ * @param  {Window} [options.win]
+ * @return {Range|undefined}
+ */
+export function createCssHighlightRange ({editableHost, start, end, win = window}) {
+  const startPoint = findRangeBoundary(editableHost, start, false)
+  const endPoint = findRangeBoundary(editableHost, end, true)
+  if (!startPoint || !endPoint) return
+
+  const range = createRange(win)
+  range.setStart(startPoint.node, startPoint.offset)
+  range.setEnd(endPoint.node, endPoint.offset)
+  return range
+}
+
+/**
+ * Take away all marks of a kind. The registry belongs to the window, not to
+ * an editable, so marks stay around until someone removes them.
+ *
+ * @param  {Object} options
+ * @param  {String} options.name
+ * @param  {Window} [options.win]
+ */
+export function clearCssHighlight ({name, win = window}) {
+  win.CSS.highlights.delete(name)
+}
+
+/**
+ * Count how far into a block a DOM position sits, the other way round from
+ * findRangeBoundary(). Counts the same characters as getCssHighlightText() so
+ * that a cursor and a mark agree on where they are.
+ *
+ * @param  {DOMNode} element
+ * @param  {DOMNode} container
+ * @param  {Number} containerOffset
+ * @return {Number|undefined}
+ */
+export function findCharacterOffset (element, container, containerOffset) {
+  // A position in an element sits before one of its children rather than
+  // inside text. Resolve it to that child so the walk can recognise it.
+  const beforeNode = container.nodeType === nodeType.elementNode
+    ? container.childNodes[containerOffset]
+    : undefined
+
+  const iterator = new NodeIterator(element)
+
+  let offset = 0
+  let next
+
+  while ((next = iterator.getNext())) {
+    if (next === beforeNode) return offset
+
+    if (next.nodeType === nodeType.elementNode && next.nodeName === 'BR') {
+      offset += 1
+      continue
+    }
+    if (next.nodeType !== nodeType.textNode || next.data === '') continue
+
+    if (next === container) return offset + containerOffset
+    offset = offset + next.data.length
+  }
+
+  // Ran off the end without meeting the container. That is the position after
+  // the last character when it came from an element, and a container the walk
+  // does not count otherwise.
+  if (!beforeNode && container.nodeType === nodeType.elementNode) return offset
+}
+
+/**
+ * Find the spot in the DOM that a character offset points at. Callers count
+ * characters, the browser wants nodes. This reads the block the same way as
+ * getCssHighlightText(), so both agree on where an offset falls.
+ *
+ * @param  {DOMNode} element
+ * @param  {Number} target
+ * @param  {Boolean} inclusive True for a range end, false for a range start.
+ * @return {Object|undefined}
+ */
+function findRangeBoundary (element, target, inclusive) {
+  const iterator = new NodeIterator(element)
+
+  let offset = 0
+  let next
+
+  while ((next = iterator.getNext())) {
+    if (next.nodeType === nodeType.elementNode && next.nodeName === 'BR') {
+      offset += 1
+      continue
+    }
+    if (next.nodeType !== nodeType.textNode || next.data === '') continue
+
+    const nodeEnd = offset + next.data.length
+    if (inclusive ? nodeEnd >= target : nodeEnd > target) {
+      return {node: next, offset: Math.max(0, target - offset)}
+    }
+
+    offset = nodeEnd
+  }
+}

--- a/src/smartQuotes.js
+++ b/src/smartQuotes.js
@@ -20,12 +20,12 @@ export const replaceQuote = (range, index, quoteType) => {
   const startContainer = range?.startContainer
   const nodeValue = startContainer?.nodeValue
   if (!nodeValue) {
-    return null
+    return false
   }
-  const newText = `${nodeValue.substring(0, index)}${quoteType}${nodeValue.substring(index + 1)}`
-  const newTextNode = document.createTextNode(newText)
-  startContainer.replaceWith(newTextNode)
-  return newTextNode
+  const at = Math.min(index, nodeValue.length)
+  startContainer.insertData(at, quoteType)
+  startContainer.deleteData(at + quoteType.length, 1)
+  return true
 }
 
 const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
@@ -38,6 +38,35 @@ const hasSingleOpeningQuote = (textArr, offset, singleOpeningQuote) => {
     }
   }
   return false
+}
+
+// Returns the quote to write in place of the typed one, or undefined if the
+// typed character should be left alone.
+const getQuote = (textArr, offset, isCharSingleQuote, {quotes, singleQuotes}) => {
+  // Special case for a single quote following a double quote,
+  // which should be transformed into a single opening quote
+  if (isCharSingleQuote && shouldBeSingleOpeningQuote(textArr, offset - 2)) {
+    return singleQuotes[0]
+  }
+
+  if (shouldBeClosingQuote(textArr, offset - 2)) {
+    if (isCharSingleQuote) {
+      // Don't transform apostrophes
+      if (hasCharAfter(textArr, offset)) {
+        return
+      }
+      // Don't transform single-quote if there is no respective single-opening-quote
+      if (!hasSingleOpeningQuote(textArr, offset, singleQuotes[0])) {
+        return
+      }
+      return singleQuotes[1]
+    }
+    return quotes[1]
+  }
+
+  if (shouldBeOpeningQuote(textArr, offset - 2)) {
+    return isCharSingleQuote ? singleQuotes[0] : quotes[0]
+  }
 }
 
 export const applySmartQuotes = (range, config, char, target, cursorOffset) => {
@@ -55,37 +84,19 @@ export const applySmartQuotes = (range, config, char, target, cursorOffset) => {
 
   const offset = range.startOffset
   const textArr = [...range.startContainer.textContent]
-  let newTextNode
 
-  // Special case for a single quote following a double quote,
-  // which should be transformed into a single opening quote
-  if (isCharSingleQuote && shouldBeSingleOpeningQuote(textArr, offset - 2)) {
-    newTextNode = replaceQuote(range, offset - 1, singleQuotes[0])
-  } else if (shouldBeClosingQuote(textArr, offset - 2)) {
-    if (isCharSingleQuote) {
-      // Don't transform apostrophes
-      if (hasCharAfter(textArr, offset)) {
-        return
-      }
-      // Don't transform single-quote if there is no respective single-opening-quote
-      if (!hasSingleOpeningQuote(textArr, offset, singleQuotes[0])) {
-        return
-      }
-    }
-    const closingQuote = isCharSingleQuote ? singleQuotes[1] : quotes[1]
-    newTextNode = replaceQuote(range, offset - 1, closingQuote)
-  } else if (shouldBeOpeningQuote(textArr, offset - 2)) {
-    const openingQuote = isCharSingleQuote ? singleQuotes[0] : quotes[0]
-    newTextNode = replaceQuote(range, offset - 1, openingQuote)
+  const quote = getQuote(textArr, offset, isCharSingleQuote, config)
+  if (!quote) {
+    return
   }
 
-  if (!newTextNode) {
+  if (!replaceQuote(range, offset - 1, quote)) {
     return
   }
 
   // Resets the cursor to the currentPosition after applying the smart-quote
   const window = target.ownerDocument.defaultView
   const selection = window.getSelection()
-  selection.collapse(newTextNode, cursorOffset ?? offset)
+  selection.collapse(range.startContainer, cursorOffset ?? offset)
 }
 


### PR DESCRIPTION
Relations:

- Resolves: https://app.notion.com/p/livingdocsio/Spellcheck-Live-check-3b3c559571d6811184e3d153c2e7a15f
- Editor PR: https://github.com/livingdocsIO/livingdocs-editor/pull/11445
- Server PR: https://github.com/livingdocsIO/livingdocs-server/pull/9840

# Description

Spellchecking needs to underline mistakes in a text, but a mistake is not part of the document. The existing highlighting wraps text in marker elements, which would put the underlines into the content. This adds a second way to highlight, built on the CSS Custom Highlight API. The browser paints the ranges and the DOM stays untouched.

- `setCssHighlight({name, ranges})` highlights character ranges under a name. One call can cover ranges in many editables, and it replaces everything held under that name. The look is up to the consumer through the `::highlight()` selector.
- `deleteCssHighlight({name})` removes the highlights of a name and forgets where they were.
- `getCssHighlightText({editableHost})` returns the text of an editable without its markup. This is the text the character offsets count against.
- `getCssHighlightCursorOffset({editableHost})` returns the cursor position as a character offset in that text, which tells a caller which highlight the cursor sits in.
- `getCssHighlightRects({editableHost, start, end})` returns where a character range sits on screen, so a caller can place a popover next to it.
- `replaceCssHighlight({editableHost, start, end, text})` replaces a character range with new text, dispatched like any other edit.

# Changelog

- 🎁 New API to highlight character ranges in an editable without changing its content, based on the CSS Custom Highlight API. Highlights survive markup changes such as comments and formatting.
